### PR TITLE
Plugin: Refactor wpcloud site and admin

### DIFF
--- a/admin/class-wpcloud-site-list.php
+++ b/admin/class-wpcloud-site-list.php
@@ -47,6 +47,7 @@ class WPCLOUD_Site_List extends WP_List_Table {
 		$columns = array(
 			'select' => '<input type="checkbox" />',
 			'site_name' => __( 'Site Name', 'wpcloud' ),
+			'owner' => __( 'Owner', 'wpcloud' ),
 			'status' => __( 'Status', 'wpcloud'),
 			'created' => __( 'Created', 'wpcloud' ),
 		);
@@ -86,6 +87,12 @@ class WPCLOUD_Site_List extends WP_List_Table {
 	public function column_created( $item ) {
 		$dt = get_post_datetime($item['id']);
 		return $dt->format('Y-m-d H:i:s');
+	}
+
+	public function column_owner( $item ) {
+		$owner_id = get_post_field( 'post_author', $item['id'] );
+		$owner = get_userdata( $owner_id );
+		return $owner->display_name;
 	}
 
 	protected function column_default( $item, $column_name ) {

--- a/admin/edit-site.php
+++ b/admin/edit-site.php
@@ -1,34 +1,45 @@
 <?php
+declare( strict_types = 1 );
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-function print_form_input_row( $label, $name, $value ) {
+
+function print_users_select( WPCloud_Site $wpcloud_site, array $filter = array() ): void {
+	$users = array_reduce( get_users($filter) , function ( $users, $user ) {
+		$users[$user->ID] = $user->display_name;
+		return $users;
+	}, array() );
+	print_form_select_row( 'Owner', 'owner_id', $users, $wpcloud_site->owner_id );
+}
+
+
+function print_form_input_row( string $label, string $name, ?string $value ): void {
 	?>
 	<tr class="wpcloud_row">
 		<th scope="row">
-			<label for="wpcloud_api_key">
+			<label for="<?php echo "wpcloud_$name" ?>">
 				<?php echo esc_html( $label ); ?>
 			</label>
 		</th>
 		<td>
-			<input type="text" id="wpcloud_api_key" name="wpcloud_site[<?php echo esc_attr( $name ); ?>]" value="<?php echo esc_attr( $value ); ?>">
+			<input type="text" id="<?php echo "wpcloud_$name" ?>" name="wpcloud_site[<?php echo esc_attr( $name ); ?>]" value="<?php echo esc_attr( $value ); ?>">
 		</td>
 	</tr>
 	<?php
 }
 
-function print_form_select_row($label, $name, $options, $value) {
+function print_form_select_row( string $label, string $name, array $options, ?string $value ): void {
 	?>
 	<tr class="wpcloud_row">
 		<th scope="row">
-			<label for="wpcloud_api_key">
+			<label for="<?php echo "wpcloud_$name" ?>">
 				<?php echo esc_html( $label ); ?>
 			</label>
 		</th>
 		<td>
-			<select id="wpcloud_api_key" name="wpcloud_site[<?php echo esc_attr( $name ); ?>]">
+			<select id="<?php echo "wpcloud_$name" ?>" name="wpcloud_site[<?php echo esc_attr( $name ); ?>]">
 				<?php
 				foreach ( $options as $option_value => $option_label ) {
 					?>
@@ -53,10 +64,11 @@ function print_form_select_row($label, $name, $options, $value) {
 			?>
 			<table class="form-table" role="presentation">
 				<tbody>
-					<input type="hidden" name="wpcloud_site[id]" value="<?php echo esc_attr( $wpcloud_site['id'] ); ?>" >
-					<?php print_form_input_row( 'Site Name', 'site_name', $wpcloud_site['site_name'] ); ?>
-					<?php print_form_select_row( 'PHP Version', 'php_version', WP_CLOUD_PHP_VERSIONS, $wpcloud_site['php_version'] ); ?>
-					<?php print_form_select_row( 'Data Center', 'data_center', WP_CLOUD_DATA_CENTERS, $wpcloud_site['php_version'] ); ?>
+					<input type="hidden" name="wpcloud_site[id]" value="<?php echo esc_attr( $wpcloud_site->id ); ?>" >
+					<?php print_users_select ($wpcloud_site ); ?>
+					<?php print_form_input_row( 'Site Name', 'site_name', $wpcloud_site->name ); ?>
+					<?php print_form_select_row( 'PHP Version', 'php_version', WPCLOUD_PHP_VERSIONS, $wpcloud_site->php_version ); ?>
+					<?php print_form_select_row( 'Data Center', 'data_center', WPCLOUD_DATA_CENTERS, $wpcloud_site->data_center ); ?>
 					</tbody>
 				</table>
 		<p class="submit">

--- a/admin/init.php
+++ b/admin/init.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * @package wpcloud-dashboard
+ */
+
+ declare( strict_types = 1 );
+
+add_action( 'admin_init', 'wpcloud_settings_init' );
+function wpcloud_settings_init(): void {
+	register_setting( 'wpcloud', 'wpcloud_settings' );
+
+	add_settings_section(
+		'wpcloud_section_settings',
+		__( 'Settings', 'wpcloud' ),
+		null,
+		'wpcloud'
+	);
+
+	add_settings_field(
+		'wpcloud_field_api_key',
+		__( 'API Key', 'wpcloud' ),
+		'wpcloud_field_input_cb',
+		'wpcloud',
+		'wpcloud_section_settings',
+		[
+			'label_for'         => 'wpcloud_api_key',
+			'class'             => 'wpcloud_row',
+			'wpcloud_custom_data' => 'custom',
+		]
+	);
+
+	add_settings_field(
+		'wpcloud_field_client',
+		__( 'Client Name', 'wpcloud' ),
+		'wpcloud_field_input_cb',
+		'wpcloud',
+		'wpcloud_section_settings',
+		[
+			'label_for'         => 'wpcloud_client',
+			'class'             => 'wpcloud_row',
+			'wpcloud_custom_data' => 'custom',
+		]
+	);
+
+	add_settings_field(
+		'wpcloud_field_domain',
+		__( 'Domain', 'wpcloud' ),
+		'wpcloud_field_input_cb',
+		'wpcloud',
+		'wpcloud_section_settings',
+		[
+			'label_for'         => 'wpcloud_domain',
+			'class'             => 'wpcloud_row',
+			'wpcloud_custom_data' => 'custom',
+		]
+	);
+}
+
+add_action( 'admin_menu', 'wpcloud_options_page' );
+function wpcloud_options_page(): void {
+    add_menu_page(
+        'WP Cloud',
+        'WP Cloud',
+        'manage_options',
+        'wpcloud',
+        'wpcloud_site_list_cb',
+        '',
+        20
+    );
+
+		add_submenu_page(
+			'wpcloud',
+			'New Site',
+			'Add Site',
+			'manage_options',
+			'wpcloud_admin_new_site',
+			'wpcloud_admin_new_site_cb',
+		);
+
+		add_submenu_page(
+			'wpcloud',
+			'Settings',
+			'Settings',
+			'manage_options',
+			'wpcloud_admin_settings',
+			'wpcloud_options_page_html',
+		);
+}
+
+
+function wpcloud_section_options_cb( array $args ): void {
+	?>
+	<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( '.', 'wpcloud' ); ?></p>
+	<?php
+}
+
+function wpcloud_field_domain_cb( array $args ): void {
+
+	$options = get_option( 'wpcloud_settings' );
+	// output the field
+	?>
+	<input
+		type="text"
+		id="<?php echo esc_attr( $args['label_for'] ); ?>"
+		name="wpcloud_settings[<?php echo esc_attr( $args['label_for'] ); ?>]"
+		value="<?php echo isset( $options[ $args['label_for'] ] ) ? esc_attr( $options[ $args['label_for'] ] ) : ''; ?>"
+	>
+	<?php
+}
+
+function wpcloud_field_input_cb( array $args ): void {
+
+	$options = get_option( 'wpcloud_settings' );
+	// output the field
+	?>
+	<input
+		type="text"
+		id="<?php echo esc_attr( $args['label_for'] ); ?>"
+		name="wpcloud_settings[<?php echo esc_attr( $args['label_for'] ); ?>]"
+		value="<?php echo isset( $options[ $args['label_for'] ] ) ? esc_attr( $options[ $args['label_for'] ] ) : ''; ?>"
+	>
+	<?php
+}
+
+function site_created__success( WPCloud_Site $wpcloud_site ): void {
+?>
+<div class="notice notice-success is-dismissible">
+	<p>
+		<?php echo sprintf( __( 'Provisioning  %s', 'wpcloud' ), $wpcloud_site->name ) ?>
+	</p>
+</div>
+<?php
+}
+
+function wpcloud_site_list_cb(): void {
+	// check user capabilities
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+	if ( isset( $_POST['wpcloud_site'] ) ) {
+		check_admin_referer( 'wpcloud-edit-site' );
+		$wpcloud_site = $_POST['wpcloud_site'];
+		if ( $wpcloud_site['id'] === '' ) {
+			// create a new site
+			$wpcloud_site = WPCloud_Site::create(
+				name: $wpcloud_site['site_name'],
+				php_version: $wpcloud_site['php_version'],
+				data_center: $wpcloud_site['data_center'],
+				owner_id: $wpcloud_site['owner_id']
+			);
+			if ( is_wp_error( $wpcloud_site ) ) {
+				// handle the error
+			} else {
+				add_action( 'admin_notices', function() use ( $wpcloud_site ):void {
+					site_created__success( $wpcloud_site );
+				});
+			}
+		} else {
+			// @TODO update the site
+		}
+	}
+	require_once	plugin_dir_path(__FILE__) . 'list-sites.php';
+}
+
+function wpcloud_admin_new_site_cb(): void {
+	// check user capabilities - need to add a capability for this 'wpcloud_add_site' or something
+	if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+	}
+
+	$wpcloud_site = new WPCloud_Site();
+
+	require_once  plugin_dir_path(__FILE__) . 'edit-site.php';
+}
+
+function wpcloud_options_page_html(): void {
+		// check user capabilities
+		if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+		}
+
+		if ( isset( $_GET['settings-updated'] ) ) {
+			// add settings saved message with the class of "updated"
+			add_settings_error( 'wpcloud_messages', 'wpcloud_message', __( 'Settings Saved', 'wpcloud' ), 'updated' );
+		}
+
+		settings_errors( 'wpcloud_messages' );
+		require_once  plugin_dir_path(__FILE__) . 'admin/options.php';
+}

--- a/admin/list-sites.php
+++ b/admin/list-sites.php
@@ -1,5 +1,12 @@
 <?php
+/**
+ * @package wpcloud-dashboard
+ */
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
 
+	do_action( 'admin_notices' );
 
 	require_once  plugin_dir_path(__FILE__) . 'class-wpcloud-site-list.php';
 	$wpcloud_site_list = new WPCLOUD_Site_List();

--- a/class-wpcloud-site.php
+++ b/class-wpcloud-site.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * WP Cloud Site .
+ *
+ * @package wpcloud-dashboard
+ */
+declare( strict_types = 1 );
+
+require_once  plugin_dir_path( __FILE__ ) . 'lib/wpcloud-client.php';
+
+class WPCLOUD_Site {
+
+	private static $initial_status = 'draft';
+
+	public $id;
+	public $name;
+	public $php_version;
+	public $data_center;
+	public $status;
+	public $owner_id;
+
+	public static function register_post_type(): void {
+			register_post_type( 'wpcloud_site',
+				array(
+				'labels'	=> array(
+					'name'			=> __( 'Sites', 'wpcloud' ),
+					'singular_name'	=> __( 'Site', 'wpcloud' ),
+					'add_new' => 'Add New Site',
+				),
+				'public'	=> true,
+				'has_archive' => true,
+				'show_in_rest' => true,
+				'show_in_ ui' => false,
+				'show_in_menu' => false,
+				'capabilities' => array(
+					'wpcloud_add_site' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Create a new WPCLOUD_Site from a WP_Post object.
+	 * @param WP_Post $post
+	 * @return WPCLOUD_Site
+	 */
+	public static function from_post( WP_Post $post ): self {
+		$site = new self();
+		$site->id = $post->ID;
+		$site->name = $post->post_title;
+		$site->php_version = get_post_meta( $post->ID, 'php_version', true );
+		$site->data_center = get_post_meta( $post->ID, 'data_center', true );
+		$site->status = $post->post_status;
+		$site->owner_id = $post->post_author;
+		return $site;
+	}
+
+	/**
+	 * Create a new WPCLOUD_Site from WP Cloud.
+	 * @param string $id
+	 * @return WPCLOUD_Site
+	 */
+	public static function from_client(string $id): self {
+		//@TODO: call the wpcloud API to get the site details.
+		return new self();
+	}
+
+	public static function create(string $name, string $php_version, string $data_center, ?string $owner_id): self {
+		// Set up the site info
+		$status = apply_filters( WPCLOUD_INITIAL_SITE_STATUS, self::$initial_status );
+		$post_details = array(
+			'post_type' => 'wpcloud_site',
+			'post_title' => $name,
+			'post_status' => $status,
+			'comment_status'=> 'closed',
+		);
+
+		// Check if the user is allowed to create a site.
+		if ( !$owner_id) {
+			$owner_id = get_current_user_id();
+		} else {
+			$post_details['post_author'] = $owner_id;
+		}
+
+		$should_create = apply_filters( WPCLOUD_SHOULD_CREATE_SITE, true, $owner_id );
+		if ( !$should_create ) {
+			throw new Exception( 'Site creation is disabled.' );
+		}
+
+		// Create the site CPT and set the meta data.
+		$site_id = wp_insert_post( $post_details );
+		if ( is_wp_error( $site_id ) ) {
+			throw new Exception( 'Failed to create site.' );
+		}
+
+		//We only really need these for the initial creation so we can show the user what they just created.
+		update_post_meta( $site_id, 'php_version', $php_version );
+		update_post_meta( $site_id, 'data_center', $data_center );
+
+		// @TODO: call the wpcloud API to create the site.
+
+		do_action( WPCLOUD_ACTION_SITE_CREATED, $site_id, $owner_id, 'wp-admin' );
+
+		return self::from_post( get_post( $site_id ) );
+	}
+
+	public static function find_all(?string $user_id, array $query = array() ): array {
+		if ( ! $user_id && ! current_user_can( WPCLOUD_CAN_MANAGE_SITES ) ) {
+			throw new Exception( 'Unauthorized to view all sites.');
+		}
+
+		$defaults = array(
+			'post_type' => 'wpcloud_site',
+			'posts_per_page' => -1,
+			'orderby' => 'title',
+			'order' => 'ASC',
+		);
+
+		$query = wp_parse_args( $query, $defaults );
+
+		if ( $user_id ) {
+			$query['author'] = $user_id;
+		} else
+
+		$results = new WP_Query( $query );
+
+		return array_map( self::class . '::from_post', $results->posts );
+	}
+}

--- a/init.php
+++ b/init.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once plugin_dir_path( __FILE__ ) . 'class-wpcloud-site.php';
+
+/**
+ * Set up the plugin's capabilities.
+ */
+function wpcloud_add_capabilities() {
+	$role = get_role( 'administrator' );
+	$role->add_cap( WPCLOUD_CAN_MANAGE_SITES );
+}
+
+/**
+ * Initialize the plugin.
+ */
+function wpcloud_init() {
+	wpcloud_add_capabilities();
+	WPCloud_Site::register_post_type();
+}
+add_action( 'init', 'wpcloud_init' );
+
+
+if ( is_admin() ) {
+	require_once plugin_dir_path( __FILE__ ) . 'admin/init.php';
+}

--- a/wpcloud-dashboard.php
+++ b/wpcloud-dashboard.php
@@ -9,229 +9,51 @@
  * Domain Path:     /languages
  * Version:         0.1.0
  *
- * @package         WP_Cloud_Dashboard
+ * @package        wpcloud-dashboard
  */
 
- const WP_CLOUD_PHP_VERSIONS = [
+
+/**
+ *  Actions
+ */
+define( 'WPCLOUD_ACTION_SITE_CREATED', 'wpcloud_create_site' );
+define( 'WPCLOUD_ACTION_UPDATE_SITE', 'wpcloud_update_site' );
+
+define( 'WPCLOUD_CLIENT_RESPONSE_ERROR', 'wpcloud_client_response_error' );
+define( 'WPCLOUD_CLIENT_RESPONSE_SUCCESS', 'wpcloud_client_response_success' );
+
+
+/**
+ * Filters
+ */
+define( 'WPCLOUD_SHOULD_CREATE_SITE', 'wpcloud_should_create_site' );
+define( 'WPCLOUD_INITIAL_SITE_STATUS', 'wpcloud_initial_site_status' );
+
+/**
+ * Allowed PHP versions.
+*/
+define( 'WPCLOUD_PHP_VERSIONS', array(
 	'7.4' => '7.4',
 	'8.1' => '8.1',
 	'8.2' => '8.2',
 	'8.3' => '8.3',
-];
+) );
 
-const WP_CLOUD_DATA_CENTERS = [
+/*
+ * Allowed Data Centers.
+ */
+define( 'WPCLOUD_DATA_CENTERS', array(
 	'NA' => 'No Preference',
 	'AMS' => 'Amsterdam, NL',
 	'BUR' => 'Los Angeles, CA',
 	'DCA' => 'Washington, D.C., USA',
 	'DFW' => 'Dallas, TX, USA',
-];
+) );
 
-const WPCLOUD_ACTION_CREATE_SITE = 'wpcloud_create_site';
-const WPCLOUD_ACTION_UPDATE_SITE = 'wpcloud_update_site';
+/**
+ * Capabilities
+ */
+define( 'WPCLOUD_CAN_MANAGE_SITES', 'wpcloud_manage_sites' );
 
-
-// Your code starts here.
-add_action( 'admin_init', 'wpcloud_settings_init' );
-function wpcloud_settings_init() {
-	register_setting( 'wpcloud', 'wpcloud_settings' );
-
-	add_settings_section(
-		'wpcloud_section_settings',
-		__( 'Settings', 'wpcloud' ),
-		null,
-		'wpcloud'
-	);
-
-	add_settings_field(
-		'wpcloud_field_api_key',
-		__( 'API Key', 'wpcloud' ),
-		'wpcloud_field_input_cb',
-		'wpcloud',
-		'wpcloud_section_settings',
-		[
-			'label_for'         => 'wpcloud_api_key',
-			'class'             => 'wpcloud_row',
-			'wpcloud_custom_data' => 'custom',
-		]
-	);
-
-	add_settings_field(
-		'wpcloud_field_client',
-		__( 'Client Name', 'wpcloud' ),
-		'wpcloud_field_input_cb',
-		'wpcloud',
-		'wpcloud_section_settings',
-		[
-			'label_for'         => 'wpcloud_client',
-			'class'             => 'wpcloud_row',
-			'wpcloud_custom_data' => 'custom',
-		]
-	);
-
-	add_settings_field(
-		'wpcloud_field_domain',
-		__( 'Domain', 'wpcloud' ),
-		'wpcloud_field_input_cb',
-		'wpcloud',
-		'wpcloud_section_settings',
-		[
-			'label_for'         => 'wpcloud_domain',
-			'class'             => 'wpcloud_row',
-			'wpcloud_custom_data' => 'custom',
-		]
-	);
-}
-
-function wpcloud_section_options_cb( $args ) {
-	?>
-	<p id="<?php echo esc_attr( $args['id'] ); ?>"><?php esc_html_e( '.', 'wpcloud' ); ?></p>
-	<?php
-}
-
-function wpcloud_field_domain_cb( $args ) {
-
-	$options = get_option( 'wpcloud_settings' );
-	// output the field
-	?>
-	<input
-		type="text"
-		id="<?php echo esc_attr( $args['label_for'] ); ?>"
-		name="wpcloud_settings[<?php echo esc_attr( $args['label_for'] ); ?>]"
-		value="<?php echo isset( $options[ $args['label_for'] ] ) ? esc_attr( $options[ $args['label_for'] ] ) : ''; ?>"
-	>
-	<?php
-}
-
-function wpcloud_field_input_cb( $args ) {
-
-	$options = get_option( 'wpcloud_settings' );
-	// output the field
-	?>
-	<input
-		type="text"
-		id="<?php echo esc_attr( $args['label_for'] ); ?>"
-		name="wpcloud_settings[<?php echo esc_attr( $args['label_for'] ); ?>]"
-		value="<?php echo isset( $options[ $args['label_for'] ] ) ? esc_attr( $options[ $args['label_for'] ] ) : ''; ?>"
-	>
-	<?php
-}
-
-
-add_action( 'admin_menu', 'wpcloud_options_page' );
-function wpcloud_options_page() {
-    add_menu_page(
-        'WP Cloud',
-        'WP Cloud',
-        'manage_options',
-        'wpcloud',
-        'wpcloud_site_list_cb',
-        '',
-        20
-    );
-
-		add_submenu_page(
-			'wpcloud',
-			'New Site',
-			'Add Site',
-			'manage_options',
-			'wpcloud_admin_new_site',
-			'wpcloud_admin_new_site_cb',
-		);
-
-		add_submenu_page(
-			'wpcloud',
-			'Settings',
-			'Settings',
-			'manage_options',
-			'wpcloud_admin_settings',
-			'wpcloud_options_page_html',
-		);
-}
-
-function site_created__success() {
-?>
-<div class="notice notice-success is-dismissible">
-<p><?php _e( 'Provisioning a new Site', 'sample-text-domain' ); ?></p>
-</div>
-<?php
-}
-
-function wpcloud_site_list_cb() {
-	// check user capabilities
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-	if ( isset( $_POST['wpcloud_site'] ) ) {
-		check_admin_referer( 'wpcloud-edit-site' );
-		$wpcloud_site = $_POST['wpcloud_site'];
-		$wpcloud_site['user_id'] = get_current_user_id();
-		if ( $wpcloud_site['id'] !== '' ) {
-			do_action( WPCLOUD_ACTION_UPDATE_SITE, $wpcloud_site);
-		}
-		else {
-			$site_id = wp_insert_post( array(
-				'post_type' => 'wpcloud_site',
-				'post_title' => $wpcloud_site['site_name'],
-				'post_status' => 'draft',
-				'comment_status'=> 'closed',
-			) );
-			add_action( 'admin_notices', 'site_created__success' );
-			do_action( WPCLOUD_ACTION_CREATE_SITE, $wpcloud_site);
-		}
-	}
-	require_once	plugin_dir_path(__FILE__) . 'admin/list-sites.php';
-}
-
-function wpcloud_admin_new_site_cb() {
-	// check user capabilities - need to add a capability for this 'wpcloud_add_site' or something
-	if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-	}
-
-	$wpcloud_site = array(
-		'id' => '',
-		'site_name' => '',
-		'php_version' => '',
-		'datacenter' => '',
-	);
-
-	require_once  plugin_dir_path(__FILE__) . 'admin/edit-site.php';
-}
-
-function wpcloud_options_page_html() {
-		// check user capabilities
-		if ( ! current_user_can( 'manage_options' ) ) {
-				return;
-		}
-
-		if ( isset( $_GET['settings-updated'] ) ) {
-			// add settings saved message with the class of "updated"
-			add_settings_error( 'wpcloud_messages', 'wpcloud_message', __( 'Settings Saved', 'wpcloud' ), 'updated' );
-		}
-
-		settings_errors( 'wpcloud_messages' );
-		require_once  plugin_dir_path(__FILE__) . 'admin/options.php';
-}
-
-function wpcloud_site_post_type() {
-	register_post_type( 'wpcloud_site',
-		array(
-			'labels'	=> array(
-				'name'			=> __( 'Sites', 'wpcloud' ),
-				'singular_name'	=> __( 'Site', 'wpcloud' ),
-				'add_new' => 'Add New Site',
-			),
-			'public'	=> true,
-			'has_archive' => true,
-			'show_in_rest' => true,
-			'show_in_ ui' => false,
-			'show_in_menu' => false,
-			'capabilities' => array(
-				'wpcloud_add_site' => true,
-			),
-
-		)
-	);
-}
-add_action( 'init', 'wpcloud_site_post_type' );
+// Initialize the plugin.
+require_once plugin_dir_path( __FILE__ ) . 'init.php';


### PR DESCRIPTION
Refactoring is good for the soul

- Created `WPCloud_Site` class with create, find, from_post, and from_client methods, plus a few others. That last one is stubbed till client.get_site is ready
- Define some plugin constants in the main plugin file
- Simplified the core initialization to `init.php`
- Moved all the admin initialization to `admin/init.php`

Also added a few more details to the creating the site