### PR TITLE
Update site list

### DIFF
--- a/wpcloud-dashboard/admin/init.php
+++ b/wpcloud-dashboard/admin/init.php
@@ -134,6 +134,7 @@ function site_created__success( WPCloud_Site $wpcloud_site ): void {
 }
 
 function wpcloud_site_list_cb(): void {
+
 	// check user capabilities
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
@@ -147,7 +148,7 @@ function wpcloud_site_list_cb(): void {
 				name: $wpcloud_site['site_name'],
 				php_version: $wpcloud_site['php_version'],
 				data_center: $wpcloud_site['data_center'],
-				owner_id: $wpcloud_site['owner_id']
+				owner_id: intval($wpcloud_site['owner_id'])
 			);
 			if ( is_wp_error( $wpcloud_site ) ) {
 				error_log( $wpcloud_site->get_error_message());

--- a/wpcloud-dashboard/includes/class-wpcloud-site.php
+++ b/wpcloud-dashboard/includes/class-wpcloud-site.php
@@ -57,9 +57,7 @@ class WPCLOUD_Site {
 				'show_in_rest' => true,
 				'show_in_ ui' => false,
 				'show_in_menu' => false,
-				'capabilities' => array(
-					'wpcloud_add_site' => true,
-				),
+				'taxonomies' => array( 'category', 'tag' ),
 			)
 		);
 	}
@@ -90,25 +88,31 @@ class WPCLOUD_Site {
 		return new self();
 	}
 
-	public static function create(string $name, string $php_version, string $data_center, ?string $owner_id): mixed {
-		// Set up the site info
-		$status = apply_filters( WPCLOUD_INITIAL_SITE_STATUS, self::$initial_status );
-		$post_details = array(
-			'post_type' => 'wpcloud_site',
-			'post_title' => $name,
-			'post_status' => $status,
-			'comment_status'=> 'closed',
-		);
+	public function delete( ): mixed {
+		$wpcloud_id = get_post_meta( $this->id, 'wpcloud_id', true );
 
+		if ( ! $wpcloud_id ) {
+			return new WP_Error( 'not_found', __( 'WP Cloud site id not found.' ) );
+		}
+
+		$result = wpcloud_client_site_delete( intval( $wpcloud_id ) );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		error_log( 'Result from wpcloud_client_site_delete: ' . print_r( $result, true ) );
+
+		return true;
+	}
+
+	public static function create(string $name, string $php_version, string $data_center, ?int $owner_id): mixed {
 		// Check if the user is allowed to create a site.
-		if ( !$owner_id) {
+		if ( ! $owner_id) {
 			$owner_id = get_current_user_id();
-		} else {
-			$post_details['post_author'] = $owner_id;
 		}
 
 		$should_create = apply_filters( WPCLOUD_SHOULD_CREATE_SITE, true, $owner_id );
-		if ( !$should_create ) {
+		if ( ! $should_create ) {
 			return new WP_Error( 'forbidden', __( 'Site creation is disabled.' ) );
 		}
 
@@ -117,16 +121,6 @@ class WPCLOUD_Site {
 		if ( ! preg_match( $pattern, $name ) ) {
 			return new WP_Error( 'forbidden', __( 'Invalid site name.' ) );
 		}
-
-		// Create the site CPT and set the meta data.
-		$site_id = wp_insert_post( $post_details );
-		if ( is_wp_error( $site_id ) ) {
-			return $site_id;
-		}
-
-		//We only really need these for the initial creation so we can show the user what they just created.
-		update_post_meta( $site_id, 'php_version', $php_version );
-		update_post_meta( $site_id, 'data_center', $data_center );
 
 		$domain = self::get_default_domain( $name );
 		$admin =  get_user_by( 'id', $owner_id );
@@ -146,26 +140,63 @@ class WPCLOUD_Site {
 			data: $data
 		);
 
+		error_log( 'Result from wpcloud_client_site_create: ' . print_r( $result, true ) );
+
 		if ( is_wp_error( $result ) ) {
 			error_log( 'Error creating site: ' . $result->get_error_message() );
-			wp_delete_post( $site_id );
 			return $result;
 		}
 
-		do_action( WPCLOUD_ACTION_SITE_CREATED, $site_id, $owner_id, 'wp-admin' );
+		$result = (array) $result;
+		$site_id = self::create_post( owner_id: $owner_id, wpcloud_id: $result[ 'atomic_site_id' ], domain: $domain, data: $data );
 
+		if ( is_wp_error( $site_id ) ) {
+			error_log(  'Error creating site post: ' . $site_id->get_error_message() );
+			return $site_id;
+		}
+
+		do_action( WPCLOUD_ACTION_SITE_CREATED, $site_id, $owner_id, 'wp-admin' );
 		return self::from_post( get_post( $site_id ) );
 	}
 
-	public static function find_all(string $owner_id, array $query = array() ): mixed {
+	private static function test() {
+		error_log( 'Test' );
+	}
 
-		/*
-		this is an admin feature , move it
-		if ( ! current_user_can( WPCLOUD_CAN_MANAGE_SITES ) ) {
-			throw new Exception( 'Unauthorized to view all sites.');
+	private static function create_post(int $owner_id, int $wpcloud_id, string $domain, array $data ): mixed {
+		self::test();
+ 		$status = apply_filters( WPCLOUD_INITIAL_SITE_STATUS, self::$initial_status );
+		$post_details = array(
+			'post_type' => 'wpcloud_site',
+			'post_title' => $domain,
+			'post_status' => $status,
+			'comment_status'=> 'closed',
+			'author' => $owner_id,
+		);
+
+			// Create the site CPT and set the meta data.
+		$site_id = wp_insert_post( $post_details );
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
 		}
-		*/
 
+		update_post_meta( $site_id, 'wpcloud_id', $wpcloud_id );
+		//We only really need these for the initial creation so we can show the user what they just created.
+		update_post_meta( $site_id, 'php_version', $data[ 'php_version' ] ?? '' );
+		update_post_meta( $site_id, 'data_center', $data[ 'data_center' ] ?? '' );
+
+		return $site_id;
+	}
+
+	public static function find( int $site_id ): mixed {
+		$site = get_post( $site_id );
+		if ( ! $site ) {
+			return new WP_Error( 'not_found', __( 'Site not found.' ) );
+		}
+		return self::from_post( $site );
+	}
+
+	public static function find_all(string $owner_id, array $query = array(), bool $backfill_from_host = false ): mixed {
 		$defaults = array(
 			'post_type' => 'wpcloud_site',
 			'posts_per_page' => -1,
@@ -180,7 +211,48 @@ class WPCLOUD_Site {
 		if ( is_wp_error( $results ) ) {
 			return $results;
 		}
-
+		self::backfill_from_host( $results->posts );
 		return array_map( self::class . '::from_post', $results->posts );
+	}
+
+	private static function backfill_from_host(array $local_sites): void {
+		$remote_sites = self::fetch_all();
+		if ( is_wp_error( $remote_sites ) ) {
+			return;
+		}
+
+		$remote_ids = array_map( fn($remote_site) => $remote_site->atomic_site_id ,$remote_sites );
+		error_log( 'Remote ids: ' . print_r( $remote_ids, true ) );
+		$local_ids = array_map( function( $site ) {
+			$wpcloud_id = get_post_meta( $site->ID, 'wpcloud_id', true );
+			return $wpcloud_id ? intval( $wpcloud_id ) : 0;
+		}, $local_sites );
+
+		$missing_ids = array_diff( $remote_ids, $local_ids );
+		$missing_sites = array_filter( $remote_sites, fn( $site ) => in_array( $site->atomic_site_id, $missing_ids ) );
+
+		$owner_id = get_current_user_id();
+
+		error_log( 'Missing ids: ' . print_r( $missing_ids, true ) );
+		foreach ( $missing_sites as $site ) {
+			$site_id = self::create_post( $owner_id, intval($site->atomic_site_id), $site->domain_name, array() );
+			if ( is_wp_error( $site_id ) ) {
+				error_log( 'Error creating site post: ' . $site_id->get_error_message() );
+				continue;
+			}
+			wp_set_post_tags( $site_id, array( 'backfill' ), true );
+
+			do_action( WPCLOUD_ACTION_SITE_CREATED, $site_id, $owner_id, 'wp-admin' );
+		}
+	}
+
+	private static function fetch_all(): mixed {
+		$sites = wpcloud_client_site_list();
+		if ( is_wp_error( $sites ) ) {
+			error_log( 'Error fetching sites: ' . $sites->get_error_message() );
+			return $sites;
+		}
+		return $sites;
+		//return array_reduce( $sites, fn( $indexed, $site ) => $indexed + [ $site->atomic_site_id => (array) $site ], array() );
 	}
 }

--- a/wpcloud-dashboard/includes/wpcloud-client.php
+++ b/wpcloud-dashboard/includes/wpcloud-client.php
@@ -158,6 +158,12 @@ function wpcloud_client_site_create( string $domain, string $admin_user, string 
 	return wpcloud_client_post( null, "create-site/{$client_name}", $data );
 }
 
+function wpcloud_client_site_delete( int $wpcloud_site_id ): mixed {
+  $client_name = wpcloud_get_client_name();
+
+	return wpcloud_client_post( $wpcloud_site_id, "delete-site/{$client_name}/{$wpcloud_site_id}" );
+}
+
 /**
  * Delete a site.
  *

--- a/wpcloud-dashboard/init.php
+++ b/wpcloud-dashboard/init.php
@@ -28,6 +28,18 @@ function wpcloud_init() {
 add_action( 'init', 'wpcloud_init' );
 
 
+function on_delete_site( int $site_id ): void {
+	$site = WPCloud_Site::find( $site_id );
+	if ( ! $site ) {
+		return;
+	}
+	$result = $site->delete();
+	if ( is_wp_error( $result ) ) {
+		error_log( $result->get_error_message() );
+	}
+}
+add_action( 'before_delete_post', 'on_delete_site', 10, 1 );
+
 if ( is_admin() ) {
 	require_once plugin_dir_path( __FILE__ ) . 'admin/init.php';
 }


### PR DESCRIPTION
This pulls in sites from the remote client and backfills to the local sites. 
This is mostly for development and we'll likely want to disable this before we go live.

The issue with backfilling is that we don't know which user a site should belong to. 
Right now it assigns the site to the current admin and add the tag `backfill` 

This also wires in delete site