### PR TITLE
Change favorite in site list (frontend only)

### DIFF
--- a/theme/archive-wpcloud_site.php
+++ b/theme/archive-wpcloud_site.php
@@ -67,6 +67,15 @@ $sites = new WP_Query( array(
 		</tbody>
 	</table>
 </main><!-- #site-content -->
-
+<script>
+	const wpcloudReady = fn => document.readyState !== 'loading' ? fn() : document.addEventListener('DOMContentLoaded', fn);
+	wpcloudReady(() => {
+		document.querySelectorAll('.wpcloud-fav').forEach((fav) => {
+			fav.addEventListener('click', () => {
+				fav.querySelector('.wpcloud-list-favorite').classList.toggle('is-favorite');
+			});
+		});
+	});
+</script>
 <?php
 get_footer();

--- a/theme/inc/template-tags.php
+++ b/theme/inc/template-tags.php
@@ -124,9 +124,10 @@ if ( ! function_exists( 'wpcloud_dashboard_list_is_favorite' ) ) :
 	 */
 	function wpcloud_dashboard_list_is_favorite() {
 		// @TODO: get real favorite data
-		$is_favorite = rand( -2, 1 ) > 0 ? '★' : '';
+		$is_favorite = rand( -2, 1 ) > 0;
 
-		echo '<span class="wpcloud-is-favorite">' . $is_favorite . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$classnames = $is_favorite ? ' is-favorite' : '';
+		echo '<span class="wpcloud-list-favorite ' . $classnames  . '"></span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 endif;
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -961,7 +961,19 @@ ul#primary-menu .current-menu-item {
 			}
 		}
 	}
-}
+
+	.wpcloud-fav {
+		&:hover {
+			:not(.is-favorite)::before {
+				content: '☆';
+			}
+		}
+		.is-favorite::before {
+			content: '★';
+		}
+	}
+
+} /* end .wpcloud-site-table */
 
 /* Navigation
 --------------------------------------------- */


### PR DESCRIPTION
Adds a quick hack to set and unset a site favorite in the front end.
- Hovering a non-favorite will show an empty star
- Clicking on a non-favorite will change the cell to a solid star.
- Clicking on a favorite cell will remove the star

NOTE: The favorite status is not persisted, still need to tie that into the CPT post metadata. 


![Screen Recording 2024-04-10 at 5 56 43 PM](https://github.com/Automattic/wpcloud-dashboard/assets/744755/bdc24e64-8971-47aa-9268-8a5004e73b29)
