### PR TITLE
Add proper footer menu

### DIFF
--- a/theme/functions.php
+++ b/theme/functions.php
@@ -177,6 +177,10 @@ if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
 
+
+/**
+ * Custom functions
+ */
 add_action('init', 'wpcloud_start_session', 1);
 function wpcloud_start_session() {
 	session_start();
@@ -212,3 +216,29 @@ add_action('end_session_action','wpcloud_end_session');
 function wpcloud_end_session() {
 	session_destroy ();
 }
+
+
+function wpcloud_update_footer_nav($item_output, $item, $depth, $args ) {
+	if ( 'footer' !== $args->theme_location ) {
+		return $item_output;
+	}
+
+	if (str_contains($item->url, 'profile') ) {
+		$avatar = get_avatar( get_current_user_id(), 32 );
+		return '<a class="avatar" href="' . $item->url . '">' .$avatar . '</a>';
+	}
+
+	if (str_contains($item->url, 'settings') ) {
+		$logo = '<img src="'. get_theme_file_uri( 'assets/nav-icons/cog.svg' ) . '" alt="settings"/>';
+		return '<a href="' . $item->url . '">' . $logo  . '</a>';
+	}
+
+	if (str_contains($item->url, 'support') ) {
+		$logo = '<img src="'. get_theme_file_uri( 'assets/nav-icons/help.svg' ) . '" alt="support"/>';
+		return '<a href="' . $item->url . '">' . $logo  . '</a>';
+	}
+
+	return $item_output;
+}
+
+add_filter( 'walker_nav_menu_start_el', 'wpcloud_update_footer_nav', 10, 4 );

--- a/theme/header.php
+++ b/theme/header.php
@@ -51,6 +51,16 @@
 			);
 			?>
 		</nav><!-- #site-navigation -->
+		<nav id="profile-navigation" class="profile-navigation">
+			<?php
+			wp_nav_menu(
+				array(
+					'theme_location' => 'footer',
+					'menu_id'        => 'footer-menu',
+				)
+			);
+			?>
+		</nav>
 	</header><!-- #masthead -->
 	<div id="wpcloud-content">
 		<?php

--- a/theme/style.css
+++ b/theme/style.css
@@ -685,11 +685,36 @@ body {
 header#masthead {
 	border-right: 1px solid rgba(85, 85, 85, 0.50);
 	padding: 48px 24px;
+	display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 100vh;
+
+	#profile-navigation {
+		margin-top: auto;
+		#footer-menu {
+			display: flex;
+			width: 100%;
+			margin:0;
+			padding: 0;
+			gap: 16px;
+			align-items: center;
+			list-style-type: none;
+			li:first-child {
+				margin-right: auto;
+			}
+			.avatar img {
+				border-radius: 50%;
+				width: 32px;
+				height: 32px;
+			}
+		}
+	}
 }
 
 ul#primary-menu {
 	display: flex;
-	width: 272px;
+	width: 100%;
 	height: 100%;
 	padding: 0;
 	flex-direction: column;


### PR DESCRIPTION
Adds a footer menu to the sidebar.

<img width="497" alt="Screenshot 2024-04-10 at 11 55 53 PM" src="https://github.com/Automattic/wpcloud-dashboard/assets/744755/45749e38-e706-41c9-9cc4-2fda05dd328a">

Required:
Create a footer menu with the following pages:
- `profile`
- `settings`
- `support`

no classnames are required
