### PR TITLE
Add initial pass at a get site detail method

### DIFF
--- a/plugin/custom-post-types/wpcloud-site.php
+++ b/plugin/custom-post-types/wpcloud-site.php
@@ -166,13 +166,13 @@ function wpcloud_lookup_post_by_site_id( int $wpcloud_site_id ): mixed {
 /**
  * Get a site detail.
  *
- * @param string $key The detail key.
  * @param int|WP_Post $post The site post or ID.
+ * @param string $key The detail key.
  *
  * @return mixed The detail value. WP_Error on error.
  */
 
-function wpcloud_get_site_detail( string $key, int|WP_Post $post ): mixed {
+function wpcloud_get_site_detail( int|WP_Post $post, string $key, ): mixed {
 	if ( is_int( $post ) ) {
 		$post = get_post( $post );
 	}


### PR DESCRIPTION
This adds `wpcloud_get_site_detail($post, $key)` to return a single site detail.

For now, it's very inefficient since it will make an API call for every detail but provides a required interface for rendering a site detail block.