### PR TITLE
Make ci file system writeable

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Noticed that the workflow wasn't working on my fork of the project.