### PR TITLE
register blocks from build directory

### DIFF
--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -7,8 +7,8 @@ require_once plugin_dir_path( __FILE__ ) . 'render.php';
 
 function wpcloud_include_blocks() {
 	$block_directories = array_merge(
-		glob( __DIR__ . '/src/*' ),
-		glob( __DIR__ . '/src/components/*' )
+		glob( __DIR__ . '/build/*' ),
+		glob( __DIR__ . '/build/components/*' )
 	);
 
 	foreach( $block_directories as $block_directory ) {
@@ -17,9 +17,7 @@ function wpcloud_include_blocks() {
 		}
 
 		try {
-			register_block_type(
-				preg_replace( '/src/', 'build', $block_directory),
-			);
+			register_block_type( $block_directory );
 		} catch ( Exception $e ) {
 			error_log( 'Error registering block: ' . $e->getMessage() );
 		}


### PR DESCRIPTION
#94 removed the block source files from the plugin archive. As a result, the block initialization code was unable to find the blocks.
This changes the block initialization to always look in the build directory.