### PR TITLE
fix label attribute type

### DIFF
--- a/plugin/blocks/src/components/form-input/block.json
+++ b/plugin/blocks/src/components/form-input/block.json
@@ -24,10 +24,9 @@
 			"default": ""
 		},
 		"label": {
-			"type": "rich-text",
+			"type": "string",
 			"default": "Label",
-			"selector": ".wpcloud-block-form-input__label-content",
-			"source": "rich-text"
+			"selector": ".wpcloud-block-form-input__label-content"
 		},
 		"inlineLabel": {
 			"type": "boolean",


### PR DESCRIPTION
Fixes #103 
Switch the label type in the form input label from rich-text to string

WP Core 6.4 does not handle rich text as an attribute source or type. Switching to string works fine.