### PR TITLE
Block: add back the refresh link logic

### DIFF
--- a/plugin/blocks/src/components/button/view.js
+++ b/plugin/blocks/src/components/button/view.js
@@ -19,4 +19,61 @@
 		}
 	});
 
+	async function refreshHref( e ) {
+		const link = e.currentTarget;
+		const button = link.closest( '.wp-block-wpcloud-button[data-refresh-rate]' );
+		const refreshRate = link.dataset.refreshRate || 15000;
+		link.dataset.refresh = '';
+		setTimeout( () => {
+			link.dataset.refresh = 'true';
+		}, refreshRate );
+
+		const formData = new FormData();
+		formData.append( 'action', 'wpcloud_refresh_link' );
+		formData.append( 'site_id', button.dataset.siteId );
+		formData.append( '_wpnonce', button.dataset.nonce );
+		formData.append( 'site_detail', button.dataset.wpcloudDetail );
+		const response = await fetch(
+			'http://localhost:8888/wp-admin/admin-ajax.php',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( formData ).toString(),
+			}
+		);
+
+		const result = await response.json();
+		if ( ! result.success ) {
+			// @TODO: Show error message
+			return false;
+		}
+
+		link.href = result.data.url;
+	}
+
+ document
+		.querySelectorAll( '.wp-block-wpcloud-button[data-refresh-rate] a' )
+		.forEach( async ( link ) => {
+			const refreshRate = link.dataset.refreshRate || 15000;
+			setTimeout( () => {
+				link.dataset.refresh = 'true';
+			}, refreshRate );
+			link.addEventListener( 'click', async ( e ) => {
+				if ( link.dataset.refresh ) {
+					e.preventDefault();
+					await refreshHref( e );
+					link.click();
+				}
+				return true;
+			} );
+
+			link.addEventListener( 'contextmenu', async ( e ) => {
+				if ( link.dataset.refresh ) {
+					await refreshHref( e );
+				}
+			} );
+		} );
+
 })(window.wpcloud);


### PR DESCRIPTION
The refresh JS was removed from the site detail block but was not moved over to the button block

This restores the JS and updates the selectors to work with the button tree