### PR TITLE
Blocks: Add flow to update site meta

### DIFF
--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -61,5 +61,5 @@ function wpcloud_block_available_datacenters_options(): array {
 }
 
 function wpcloud_block_available_wp_versions(): array {
-	return array( __( "latest" ), __( "previous" ), _( "beta" ) );
+	return array( "latest" => __( "latest" ), "previous" => __( "previous" ), "beta" => _( "beta" ) );
 }

--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -59,3 +59,7 @@ function wpcloud_block_available_datacenters_options(): array {
 
 	return $available_data_centers;
 }
+
+function wpcloud_block_available_wp_versions(): array {
+	return array( __( "latest" ), __( "previous" ), _( "beta" ) );
+}

--- a/plugin/blocks/src/components/button/index.js
+++ b/plugin/blocks/src/components/button/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/block-editor';
-
 
 /**
  * Internal dependencies

--- a/plugin/blocks/src/components/controls/site/detailSelect.js
+++ b/plugin/blocks/src/components/controls/site/detailSelect.js
@@ -8,10 +8,16 @@ export default function DetailSelect( {
 	attributes,
 	setAttributes,
 	onChange,
-} ) {
+}) {
+	const { type } = attributes;
+	const selectableDetailTypes = window.wpcloud?.selectableDetails || ['wp_version', 'php_version', 'data_center' ];
+
 	const siteDetailKeys = window.wpcloud?.siteDetails || {};
 	let options = [];
-	for ( const [ key, value ] of Object.entries( siteDetailKeys ) ) {
+	for (const [key, value] of Object.entries(siteDetailKeys)) {
+		if ('select' === type && ! selectableDetailTypes.includes( key ) ) {
+			continue;
+		}
 		options.push( { value: key, label: value } );
 	}
 

--- a/plugin/blocks/src/components/form-input/edit.js
+++ b/plugin/blocks/src/components/form-input/edit.js
@@ -55,19 +55,17 @@ function InputFieldBlock( { attributes, setAttributes, className, context } ) {
 		checkbox: Text,
 	};
 
-	const selectTypeOptions = [
+	const typeOptions = [
 		{ value: 'text', label: __( 'Text' ) },
 		{ value: 'email', label: __( 'Email' ) },
 		{ value: 'password', label: __( 'Password' ) },
 		{ value: 'hidden', label: __( 'Hidden' ) },
 		{ value: 'textarea', label: __( 'Textarea' ) },
-		{ value: 'checkbox', label: __( 'Checkbox' )}
-		// @TODO Implement select block to allow setting the select options. For now it's only available in block templates.
-		// { value: 'select', label: __( 'Select' ) },
+		{ value: 'checkbox', label: __( 'Checkbox' )},
+		{ value: 'select', label: __( 'Select' ) },
 	];
 
 	const InputTag = inputTags[ type ] ? inputTags[ type ] : Text;
-
 	const showLabel = ! ( hideLabel || 'hidden' === type );
 
 	const controls = (
@@ -85,11 +83,12 @@ function InputFieldBlock( { attributes, setAttributes, className, context } ) {
 					<SelectControl
 						label={ __( 'Input Type' ) }
 						value={ type }
-						options={ selectTypeOptions }
+						options={ typeOptions }
 						onChange={ ( newType ) => {
 							setAttributes( { type: newType } );
 						} }
 					/>
+
 					<DetailSelectControl
 						attributes={ attributes }
 						setAttributes={ setAttributes }

--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -13,12 +13,10 @@ export default function SelectField( {
 	className,
 	onValueChange,
 } ) {
-	const { value, options } = attributes;
+	const { name, value, options = [{ value: '', label: ' { option }' }] } = attributes;
 
-	const controls = <></>;
 	return (
 		<>
-			{ controls }
 			<select
 				className={ classNames(
 					className,

--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -13,10 +13,14 @@ export default function SelectField( {
 	className,
 	onValueChange,
 } ) {
-	const { name, value, options = [{ value: '', label: ' { option }' }] } = attributes;
+	const { name, value } = attributes;
+	let { options } = attributes;
+
+	if (!options) {
+		options = [{ label: `{ ${name} } `, value: '' }];
+	}
 
 	return (
-		<>
 			<select
 				className={ classNames(
 					className,
@@ -32,6 +36,5 @@ export default function SelectField( {
 					</option>
 				) ) }
 			</select>
-		</>
 	);
 }

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -34,11 +34,14 @@ if ( 'select' === $type && in_array( $name, $dynamic_select_options ) ) {
 			$options = array();
 	}
 
+	$current_value = wpcloud_get_site_detail(get_the_ID(), $name);
+
 	$options_html = '';
 	foreach ( $options as $value => $label ) {
 		$options_html .= sprintf(
-			'<option value="%s">%s</option>',
+			'<option value="%s" %s>%s</option>',
 			esc_attr( $value ),
+			selected( $current_value, $value, false ),
 			esc_html( $label )
 		);
 	}

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -7,6 +7,7 @@ if ( $limit_to_admin && ! current_user_can( 'manage_options' ) ) {
 }
 
 $name = $attributes['name'] ?? 'any';
+$type = $attributes['type'] ?? 'text';
 
 $allowed = apply_filters( 'wpcloud_block_form_allow_field_' . $name,  true, $attributes, $block );
 
@@ -16,5 +17,34 @@ if ( ! $allowed ) {
 
 $content = apply_filters( 'wpcloud_block_form_render_field_' . $name, $content, $attributes, $block );
 $content = apply_filters( 'wpcloud_block_form_render_field', $content, $attributes, $block );
+
+$dynamic_select_options = array( 'php_version', 'data_center', 'wp_version' );
+if ( 'select' === $type && in_array( $name, $dynamic_select_options ) ) {
+	switch( $name ) {
+		case 'php_version':
+			$options = wpcloud_block_available_php_options();
+			break;
+		case 'data_center':
+			$options = wpcloud_block_available_datacenters_options();
+			break;
+		case 'wp_version':
+			$options = wpcloud_block_available_wp_versions();
+			break;
+		default:
+			$options = array();
+	}
+
+	$options_html = '';
+	foreach ( $options as $value => $label ) {
+		$options_html .= sprintf(
+			'<option value="%s">%s</option>',
+			esc_attr( $value ),
+			esc_html( $label )
+		);
+	}
+
+	$regex = '/(<select[^>]*>)(?:\s*<option[^>]*>.*?<\/option>)*\s*(<\/select>)/';
+	$content = preg_replace($regex, '$1' . $options_html . '$2', $content);
+}
 
 echo $content;

--- a/plugin/blocks/src/components/form-input/save.js
+++ b/plugin/blocks/src/components/form-input/save.js
@@ -40,8 +40,8 @@ function renderSelect(
 	inputClasses,
 	inputStyle
 ) {
-	if ( ! options || ! options.length ) {
-		return null;
+	if ( ! options ) {
+		options = [ { label: `{ ${ name } }`, value: '' } ];
 	}
 	return (
 		<select

--- a/plugin/blocks/src/components/form-input/save.js
+++ b/plugin/blocks/src/components/form-input/save.js
@@ -40,6 +40,9 @@ function renderSelect(
 	inputClasses,
 	inputStyle
 ) {
+	if ( ! options || ! options.length ) {
+		return null;
+	}
 	return (
 		<select
 			className={ classNames(

--- a/plugin/blocks/src/components/form/block.json
+++ b/plugin/blocks/src/components/form/block.json
@@ -19,13 +19,14 @@
 	"attributes": {
 		"ajax": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"action": {
 			"type": "string"
 		},
 		"wpcloudAction": {
-			"type": "string"
+			"type": "string",
+			"default": " "
 		},
 		"inline": {
 			"type": "boolean",
@@ -35,6 +36,10 @@
 			"type": "string"
 		},
 		"active": {
+			"type": "boolean",
+			"default": false
+		},
+		"submitOnChange": {
 			"type": "boolean",
 			"default": false
 		}

--- a/plugin/blocks/src/components/form/edit.js
+++ b/plugin/blocks/src/components/form/edit.js
@@ -38,7 +38,7 @@ export default function Edit( {
 	clientId,
 	isSelected,
 } ) {
-	const { action, ajax, wpcloudAction, inline, redirect } = attributes;
+	const { action, ajax, wpcloudAction, inline, redirect, submitOnChange } = attributes;
 	const blockProps = useBlockProps();
 
 	const isChildSelected = useSelect( ( select ) =>
@@ -92,7 +92,7 @@ export default function Edit( {
 
 					<ToggleControl
 						label={ __( 'Enable AJAX' ) }
-						checked={ attributes.ajax }
+						checked={ ajax }
 						onChange={ ( newValue ) =>
 							setAttributes( { ajax: newValue } )
 						}
@@ -100,6 +100,17 @@ export default function Edit( {
 							'Enable AJAX form submission for a smoother experience.'
 						) }
 					/>
+					{ ajax && (
+						<ToggleControl
+							label={__('Submit on Change')}
+							checked={submitOnChange}
+							onChange={(newValue) =>
+								setAttributes({ submitOnChange: newValue })
+							}
+							help={__(
+								'Submits the form when a field is changed. Does not apply to text inputs'
+							)}
+						/>)}
 					<TextControl
 						label={ __( 'Redirect' ) }
 						value={ redirect }

--- a/plugin/blocks/src/components/form/index.php
+++ b/plugin/blocks/src/components/form/index.php
@@ -6,21 +6,29 @@ function wpcloud_block_form_hidden_field( $name, $value ) {
 
 function wpcloud_form_submit_handler() {
 	check_ajax_referer( 'wpcloud_form' );
-	$action = $_POST[ 'wpcloud_action' ] ?? '';
+	$action = trim($_POST[ 'wpcloud_action' ] ?? '');
+
+	$post_data = $_POST;
+
+	if ( isset($post_data[ 'site_id' ]) ) {
+		$post_data[ 'wpcloud_site_id' ] = get_post_meta($post_data[ 'site_id' ], 'wpcloud_site_id', true);
+	}
 
 	// Get the form fields.
 	$fields = apply_filters( 'wpcloud_block_form_submitted_fields', array(
 		'wpcloud_action',
 		'redirect',
-	), array_keys( $_POST ) );
-	$fields = apply_filters( 'wpcloud_block_form_submitted_fields_' . $action , $fields, array_keys( $_POST ) );
+		'wpcloud_site_id',
+	), array_keys( $post_data ) );
 
+
+	$fields = apply_filters( 'wpcloud_block_form_submitted_fields_' . $action , $fields, array_keys( $post_data ) );
 
 	// Get the form data.
 	$data = array();
 	foreach ( $fields as $field ) {
-		if ( isset( $_POST[ $field ] ) ) {
-			$data[ $field ] = sanitize_text_field( wp_unslash( $_POST[ $field ] ) );
+		if ( isset( $post_data[ $field ] ) ) {
+			$data[ $field ] = sanitize_text_field( wp_unslash( $post_data[ $field ] ) );
 		}
 	}
 

--- a/plugin/blocks/src/components/form/render.php
+++ b/plugin/blocks/src/components/form/render.php
@@ -6,6 +6,11 @@ $processed_content->next_tag( 'form' );
 $fields = apply_filters( 'wpcloud_block_form_fields', '', $attributes );
 $fields .= wpcloud_block_form_hidden_field( 'action', 'wpcloud_block_form_submit' );
 
+$submitOnChange = $attributes['submitOnChange'] ?? false;
+if ( $submitOnChange ) {
+	$processed_content->set_attribute( 'data-submit-on-change', 'true' );
+}
+
 if ( isset( $attributes[ 'wpcloudAction' ] ) && $attributes[ 'wpcloudAction' ] ) {
 	$fields .= wpcloud_block_form_hidden_field( 'wpcloud_action', $attributes[ 'wpcloudAction' ] );
 	$processed_content->set_attribute( 'data-original-action', $attributes[ 'wpcloudAction' ] );

--- a/plugin/blocks/src/components/form/view.js
+++ b/plugin/blocks/src/components/form/view.js
@@ -4,7 +4,7 @@
 
 		form.addEventListener( 'submit', async ( e ) => {
 			e.preventDefault();
-			button.setAttribute( 'disabled', 'disabled' );
+			button && button.setAttribute( 'disabled', 'disabled' );
 			form.classList.add( 'is-loading' );
 			form.classList.remove( 'is-error' );
 
@@ -81,7 +81,7 @@
 					window.location = result.data.redirect;
 				}
 
-				button.removeAttribute( 'disabled' );
+				button && button.removeAttribute( 'disabled' );
 				form.classList.remove( 'is-loading' );
 
 				if ( ! response.ok ) {
@@ -91,7 +91,19 @@
 				/* eslint-disable no-console */
 				console.error( error );
 			}
-		} );
+		});
+
+		const submitOnChange = form.dataset.submitOnChange;
+		if ( submitOnChange ) {
+			form.querySelectorAll('input, select').forEach((input) => {
+				if (input.type === 'text') {
+					return;
+				}
+				input.addEventListener('change', () => {
+					form.dispatchEvent(new Event('submit'));
+				});
+			});
+		}
 	};
 
 	// Fill in any missing hidden inputs closest data attribute

--- a/plugin/blocks/src/components/icon/block.json
+++ b/plugin/blocks/src/components/icon/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Icon",
 	"category": "wpcloud",
-	"icon": "image",
+	"icon": "star-filled",
 	"description": "Render a WordPress Icon. See https://wordpress.github.io/gutenberg/?path=/story/icons-icon--library",
 	"example": {},
 	"supports": {

--- a/plugin/blocks/src/site-create/index.php
+++ b/plugin/blocks/src/site-create/index.php
@@ -65,6 +65,7 @@ function wpcloud_block_site_form_enqueue_scripts() {
 		'window.wpcloud = window.wpcloud ?? {};' .
 		 'wpcloud.siteDetails=' . json_encode( WPCloud_Site::get_detail_options() ) . ';' .
 		 'wpcloud.phpVersions=' . json_encode( wpcloud_block_available_php_options() ) . ';' .
+		 'wpcloud.wpVersions=' . json_encode( wpcloud_block_available_wp_versions() ) . ';' .
 		 'wpcloud.dataCenters=' . json_encode( wpcloud_block_available_datacenters_options() ) . ';' .
 		 'wpcloud.linkableSiteDetails=' . json_encode( WPCloud_Site::get_linkable_detail_options() ) . ';'
 	);

--- a/plugin/blocks/src/site-update/block.json
+++ b/plugin/blocks/src/site-update/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wpcloud/site-update",
+	"version": "0.1.0",
+	"title": "Update Site Block",
+	"category": "wpcloud",
+	"icon": "feedback",
+	"description": "Handle site updates",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"textdomain": "wpcloud",
+	"editorScript": "file:./index.js"
+}

--- a/plugin/blocks/src/site-update/index.js
+++ b/plugin/blocks/src/site-update/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: () => (<InnerBlocks />),
+	save: () => (<InnerBlocks.Content />),
+} );

--- a/plugin/blocks/src/site-update/index.php
+++ b/plugin/blocks/src/site-update/index.php
@@ -5,13 +5,28 @@ function wpcloud_block_form_site_update_fields( array $fields ): array {
 		return $field !== false;
 	} );
 
-	return array_merge( array_keys($fields), $meta_fields );
+	return array_merge( $fields, array_keys( $meta_fields ) );
 }
 add_filter( 'wpcloud_block_form_submitted_fields_site_update', 'wpcloud_block_form_site_update_fields' );
 
 function wpcloud_block_form_site_update_handler($response, $data) {
-	error_log( 'wpcloud_block_form_site_update_handler' );
-	error_log( print_r( $data, true ) );
+	$meta_fields = array_keys( WPCloud_Site::get_meta_fields() );
+
+	$site_meta = array_filter( $data, function( $value, $key ) use ( $meta_fields ){
+		return in_array( $key, $meta_fields );
+	}, ARRAY_FILTER_USE_BOTH );
+
+	foreach ( $site_meta as $key => $value) {
+		$result = wpcloud_client_update_site_meta( $data['wpcloud_site_id'], $key, $value );
+		if ( is_wp_error( $result ) ) {
+			$response['success'] = false;
+			$response['message'] = $result->get_error_message();
+			$response['status'] = 400;
+			return $response;
+		}
+	}
+
+	$response['message'] = 'Site updated successfully.';
 	return $response;
 }
-add_filter('wpcloud_form_process_update_create', 'wpcloud_block_form_site_update_handler', 10, 2);
+add_filter('wpcloud_form_process_site_update', 'wpcloud_block_form_site_update_handler', 10, 2);

--- a/plugin/blocks/src/site-update/index.php
+++ b/plugin/blocks/src/site-update/index.php
@@ -1,0 +1,17 @@
+<?php
+
+function wpcloud_block_form_site_update_fields( array $fields ): array {
+	$meta_fields = array_filter( WPCloud_Site::get_meta_fields(), function( $field ) {
+		return $field !== false;
+	} );
+
+	return array_merge( array_keys($fields), $meta_fields );
+}
+add_filter( 'wpcloud_block_form_submitted_fields_site_update', 'wpcloud_block_form_site_update_fields' );
+
+function wpcloud_block_form_site_update_handler($response, $data) {
+	error_log( 'wpcloud_block_form_site_update_handler' );
+	error_log( print_r( $data, true ) );
+	return $response;
+}
+add_filter('wpcloud_form_process_update_create', 'wpcloud_block_form_site_update_handler', 10, 2);

--- a/plugin/custom-post-types/wpcloud-site.php
+++ b/plugin/custom-post-types/wpcloud-site.php
@@ -595,12 +595,18 @@ function wpcloud_get_site_detail( int|WP_Post $post, string $key, ): mixed {
 
 			return 'https://' . $result->domain_name . '/wp-admin';
 
+		case 'data_center':
+			$key = 'geo_affinity';
 		default:
 			$result = wpcloud_client_site_details( $wpcloud_site_id, true );
 	}
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
+	}
+
+	if ('geo_affinity' === $key) {
+		return $result->extra->server_pool->geo_affinity;
 	}
 
 	if ( ! isset( $result->$key ) ) {

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -132,6 +132,38 @@ class WPCLOUD_Site {
 		);
 	}
 
+	/**
+	 * Get the meta keys for a WPCLOUD_Site.
+	 *
+	 * see https://wp.cloud/apidocs-webhost/#api-Sites-site-meta
+	 * if a key is false, it is only used for getting the value
+	 * @return array
+	 */
+	public static function get_meta_fields(): array {
+		return [
+			// db_charset and db_collate should be paired
+			"db_charset" => [ "latin1 "=> "latin1", "utf8" => "utf8", "utf8mb4" => "utf8mb4" ],
+			"db_collate" => [ "latin1_swedish_ci" => "latin1_swedish_ci", "utf8_general_ci" => "utf8_general_ci", "utf8mb4_unicode_ci" => "utf8mb4_unicode_ci" ],
+			"suspended" => [ "404" => "404", "410" => "410", "451" => "451", "480" => "480" ],
+			"suspend_after" => [], // unix timestamp
+			"php_version" => wpcloud_client_php_versions_available(),
+			"wp_version" => [ "latest" => __("latest"), "previous" => __("previous"), "beta" => __("beta") ],
+			"do_not_delete" => [ 0 => "false", 1 => "true" ], // truthy enables do_not_delete
+			"space_used" => false, // get only
+			"db_file_size" => false, // get only
+			"space_quota" => [], // integer + unit ie. 100M,
+			"max_space_quota" => false,
+			"photon_subsizes" => [ "0", "1", "deleted"],
+			"privacy_model" => [ "wp_uploads" ] ,
+			"geo_affinity" => wpcloud_client_data_centers_available(),
+			"static_file_404" => ["lightweight", "wordpress"],
+			"default_php_conns" => range(2,10),
+			"burst_php_conns" => [0 => "disabled", 1 => "enabled"],
+			"php_fs_permissions" => [ "rw" => __( "Read/Write"), "ro" => __( "Read Only"), "loggedin" => __("Read only unless logged into WordPress") ],
+			"canonicalize_aliases" => [ 0 => "false", 1 => "true" ],
+		];
+	}
+
 	public static function get_linkable_detail_options(): array {
 		return array_intersect_key( self::get_detail_options(),  array_flip( self::LINKABLE_DETAIL_KEYS ) );
 	}

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -527,6 +527,30 @@ function wpcloud_client_ssh_user_remove( int $wpcloud_site_id, string $user ): m
 }
 
 /**
+ *
+ * Update site meta.
+ *
+ * Also handles updates for the WordPress version via the `site-wordpress-version` endpoint.
+ *
+ * @param integer $wpcloud_site_id The WP Cloud Site ID.
+ * @param string  $key            The meta key to update.
+ * @param string|null $value       The value to set. If null, the key will be removed.
+ *
+ * @return mixed|WP_Error Response body on success. WP_Error on failure.
+ */
+function wpcloud_client_update_site_meta( int $wpcloud_site_id, string $key, string|null $value): mixed {
+	$endpoint = "site-meta/$wpcloud_site_id/$key/update";
+	if ( "wp_version" === $key ) {
+		$endpoint =  "site-wordpress-version/$wpcloud_site_id/$value";
+	}
+	if ( is_null($value) ) {
+		$endpoint = "site-meta/$wpcloud_site_id/$key/remove";
+
+	}
+	return wpcloud_client_post( $wpcloud_site_id, $endpoint, array("value" => $value) );
+}
+
+/**
  * Get the status of a job.
  *
  * @param integer $job_id The job id for which to get the status.


### PR DESCRIPTION
This adds a simple block to handle updating the site meta.
- Adds the select option to the form input (for now it can only handle a PHP version, wp version and data center )
- Add `site-meta` updates in the client
- Updates the form block to handle update on change events
