### PR TITLE
SSH: allow updating existin ssh user and add some basic ssh admin options

### DIFF
--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -19,6 +19,12 @@ $content = apply_filters( 'wpcloud_block_form_render_field_' . $name, $content, 
 $content = apply_filters( 'wpcloud_block_form_render_field', $content, $attributes, $block );
 
 $site_meta_options = WPCloud_Site::get_meta_options();
+//add in site ssh connection
+$site_meta_options['site_access_with_ssh'] = [
+	'label' => 'Access with SSH',
+	'type' => 'checkbox',
+	'default' => true,
+];
 if ( array_key_exists($name, $site_meta_options) ) {
 	$current_value = wpcloud_get_site_detail(get_the_ID(), $name);
 	if ( is_wp_error( $current_value ) ) {

--- a/plugin/blocks/src/components/form-input/view.js
+++ b/plugin/blocks/src/components/form-input/view.js
@@ -1,6 +1,5 @@
 (() => {
 	const passwordToggle = document.querySelectorAll('.wpcloud-block-form-input--toggle-hidden');
-	console.log(passwordToggle);
 	passwordToggle.forEach((toggle) => {
 		toggle.addEventListener('click', () => {
 			const input = toggle.closest('.wpcloud-block-form-input--password').querySelector('.wpcloud-block-form-input__input');
@@ -15,5 +14,4 @@
 			}
 		});
 	});
-
 })();

--- a/plugin/blocks/src/components/site-template/view.js
+++ b/plugin/blocks/src/components/site-template/view.js
@@ -1,5 +1,4 @@
 (() => {
-	console.log('site-template view.js');
 	document.querySelectorAll('.wpcloud-site-template tr, .wp-block-query .wp-block-wpcloud-site-card').forEach((row) => {
 		row.addEventListener('click', (event) => {
 			const targetLink = event.target.closest('a');

--- a/plugin/blocks/src/components/ssh-user-form/index.php
+++ b/plugin/blocks/src/components/ssh-user-form/index.php
@@ -5,10 +5,11 @@
  * @param array $fields The form fields.
  * @return array The form fields.
  */
-function wpcloud_block_form_site_ssh_user_add_fields( array $fields) {
+function wpcloud_block_form_site_ssh_user_fields( array $fields) {
 	return array_merge( $fields, [ 'pass', 'pkey', 'user' ] );
 }
-add_filter('wpcloud_block_form_submitted_fields_site_ssh_user_add', 'wpcloud_block_form_site_ssh_user_add_fields' );
+add_filter( 'wpcloud_block_form_submitted_fields_site_ssh_user_add', 'wpcloud_block_form_site_ssh_user_fields' );
+add_filter( 'wpcloud_block_form_submitted_fields_site_ssh_user_update', 'wpcloud_block_form_site_ssh_user_fields' );
 
 /**
  * Process the form data for add ssh user
@@ -17,7 +18,7 @@ add_filter('wpcloud_block_form_submitted_fields_site_ssh_user_add', 'wpcloud_blo
  * @param array $data The form data.
  * @return array The response data.
  */
-function wpcloud_block_form__site_ssh_user_add_handler( $response, $data ) {
+function wpcloud_block_form_site_ssh_user_add_handler( $response, $data ) {
 	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
 
 	if ( ! $wpcloud_site_id ) {
@@ -47,4 +48,29 @@ function wpcloud_block_form__site_ssh_user_add_handler( $response, $data ) {
 
 	return $response;
 }
-add_filter('wpcloud_form_process_site_ssh_user_add', 'wpcloud_block_form__site_ssh_user_add_handler', 10, 2);
+add_filter('wpcloud_form_process_site_ssh_user_add', 'wpcloud_block_form_site_ssh_user_add_handler', 10, 2);
+
+
+function wpcloud_block_form_site_ssh_user_update_handler( $response, $data) {
+	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
+
+	if ( ! $wpcloud_site_id ) {
+		$response['message'] = 'Site not found.';
+		$response['status'] = 400;
+		return $response;
+	}
+	$result = wpcloud_client_ssh_user_update( $wpcloud_site_id, $data['user'], $data['pkey'], $data['pass'] );
+
+	if ( is_wp_error( $result ) ) {
+		$response['success'] = false;
+		$response['message'] = $result->get_error_message();
+		$response['status'] = 400;
+		return $response;
+	}
+
+	$response['message'] = 'SSH user updated successfully.';
+	$response['user'] = $result;
+
+	return $response;
+}
+add_filter('wpcloud_form_process_site_ssh_user_update', 'wpcloud_block_form_site_ssh_user_update_handler', 10, 2);

--- a/plugin/blocks/src/components/ssh-user-form/view.js
+++ b/plugin/blocks/src/components/ssh-user-form/view.js
@@ -1,21 +1,38 @@
-( ( wpcloud ) => {
+((wpcloud) => {
 	/**
 	 * Handle the response from the site alias add form.
 	 * @param {Object} result - The response from the server.
 	 */
-	function onSiteSshUserAdd( result ) {
+	function onSiteSshUserAdd( result, form ) {
 		if ( ! result.success ) {
 			alert( result.message ); // eslint-disable-line no-alert, no-undef
 			return;
 		}
-		// @TODO: clear the ssh add user form
-
 		wpcloud.hooks.doAction( 'wpcloud_site_ssh_user_added', result.user );
 	}
-
 	wpcloud.hooks.addAction(
 		'wpcloud_form_response_site_ssh_user_add',
 		'site_ssh_user_add',
 		onSiteSshUserAdd
+	);
+
+	function onSiteSshUserUpdate( result, form ) {
+		if ( ! result.success ) {
+			alert( result.message ); // eslint-disable-line no-alert, no-undef
+			return;
+		}
+		// Close the form section.
+		const section = form.closest(
+			'.wpcloud-ssh-user-form--expanding-section'
+		);
+		wpcloud.hooks.doAction(
+			'wpcloud_expanding_section_toggle',
+			section
+		);
+	}
+	wpcloud.hooks.addAction(
+		'wpcloud_form_response_site_ssh_user_update',
+		'site_ssh_user_update',
+		onSiteSshUserUpdate
 	);
 } )( window.wpcloud );

--- a/plugin/blocks/src/site-ssh-settings/block.json
+++ b/plugin/blocks/src/site-ssh-settings/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wpcloud/site-ssh-settings",
+	"version": "0.1.0",
+	"title": "Site SSH Settings",
+	"category": "wpcloud",
+	"icon": "cloud",
+	"description": "Handle site updates",
+	"example": {},
+	"supports": {
+		"html": false
+	},
+	"textdomain": "wpcloud",
+	"editorScript": "file:./index.js"
+}

--- a/plugin/blocks/src/site-ssh-settings/index.js
+++ b/plugin/blocks/src/site-ssh-settings/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+
+const template = [
+	['wpcloud/site-details',
+		{},
+		[
+			['core/heading',
+				{
+					level: 3,
+					className: "wpcloud-site-detail-card__title",
+					content: __('SSH Users')
+				}
+			],
+			['wpcloud/form',
+				{
+					wpcloudAction: 'site_ssh_disconnect_all_users',
+				},
+				[
+					['wpcloud/button',
+						{
+							label: __('Disconnect All Users'),
+							className: 'wpcloud-block-button--danger',
+							type: 'submit',
+						}
+					]
+				]
+			],
+			['wpcloud/form',
+				{
+					wpcloudAction: 'site_access_type',
+				},
+				[
+					['wpcloud/form-input',
+						{
+							type: "checkbox",
+							name: "site_access_with_ssh",
+							label: __('Access via SSH (if disabled, SFTP will be used)'),
+							displayAsToggle: true,
+							submitOnChange: true,
+						}
+					]
+				]
+			]
+		]
+	]
+];
+
+registerBlockType(metadata.name, {
+	edit: () => <InnerBlocks template={template} />,
+	save: () => <InnerBlocks.Content />,
+});

--- a/plugin/blocks/src/site-ssh-settings/index.php
+++ b/plugin/blocks/src/site-ssh-settings/index.php
@@ -1,0 +1,57 @@
+<?php
+
+function wpcloud_block_form_site_access_type_fields( array $fields ): array {
+	return array_merge( $fields, [ 'site_access_with_ssh' ] );
+}
+add_filter( 'wpcloud_block_form_submitted_fields_site_access_type', 'wpcloud_block_form_site_access_type_fields' );
+
+function wpcloud_block_form_site_access_type_handler( $response, $data ) {
+	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
+
+	if ( ! $wpcloud_site_id ) {
+		$response['message'] = 'Site not found.';
+		$response['status'] = 400;
+		return $response;
+	}
+
+	$site_access_type =  $data['site_access_with_ssh'] === "1" ? 'ssh' : 'sftp';
+
+	$result = wpcloud_client_site_set_access_type( $wpcloud_site_id, $site_access_type );
+
+	if ( is_wp_error( $result ) ) {
+		$response['success'] = false;
+		$response['message'] = $result->get_error_message();
+		$response['status'] = 400;
+		return $response;
+	}
+
+	$response['message'] = "Site access type updated successfully to $site_access_type.";
+
+	return $response;
+}
+add_filter('wpcloud_form_process_site_access_type', 'wpcloud_block_form_site_access_type_handler', 10, 2);
+
+
+function wpcloud_block_form_site_ssh_disconnect_all_users_handler( $response, $data ) {
+	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
+
+	if ( ! $wpcloud_site_id ) {
+		$response['message'] = 'Site not found.';
+		$response['status'] = 400;
+		return $response;
+	}
+
+	$result = wpcloud_client_ssh_disconnect_all_users( $wpcloud_site_id );
+
+	if ( is_wp_error( $result ) ) {
+		$response['success'] = false;
+		$response['message'] = $result->get_error_message();
+		$response['status'] = 400;
+		return $response;
+	}
+
+	$response['message'] = 'SSH users disconnected successfully.';
+
+	return $response;
+}
+add_filter('wpcloud_form_process_site_ssh_disconnect_all_users', 'wpcloud_block_form_site_ssh_disconnect_all_users_handler', 10, 2);

--- a/plugin/blocks/src/site-ssh-users/view.js
+++ b/plugin/blocks/src/site-ssh-users/view.js
@@ -18,6 +18,7 @@
 			);
 			const nameInput = form.querySelector( 'input[name="user"]' );
 			nameInput.value = sshUserName;
+			nameInput.readOnly = true;
 
 			const submit = form.querySelector( 'button[type="submit"]' );
 			submit.querySelector( '.wpcloud-block-button__label' ).textContent =
@@ -26,7 +27,7 @@
 			const wpCloudAction = form.querySelector(
 				'input[name="wpcloud_action"]'
 			);
-			wpCloudAction.value = 'wpcloud_ssh_user_update';
+			wpCloudAction.value = 'site_ssh_user_update';
 
 			// Open the form section if it's not open already.
 			const section = form.closest(
@@ -70,9 +71,9 @@
 			input.value = '';
 		} );
 
-		const originalLabel = form.dataset.originalLabel;
+		const submit = form.querySelector( 'button[type="submit"]' );
+		const originalLabel = submit?.dataset.originalLabel;
 		if ( originalLabel ) {
-			const submit = form.querySelector( 'button[type="submit"]' );
 			submit.querySelector( '.wpcloud-block-button__label' ).textContent =
 				originalLabel;
 		}

--- a/plugin/custom-post-types/wpcloud-site.php
+++ b/plugin/custom-post-types/wpcloud-site.php
@@ -614,6 +614,9 @@ function wpcloud_get_site_detail( int|WP_Post $post, string $key, ): mixed {
 			$gigs = round($bytes / pow(1024, $i), 2);
 			return $gigs .'G';
 
+		case 'site_access_with_ssh':
+			// @TODO: not sure how we can tell if the site is using ssh or sftp
+			return true;
 
 		case 'data_center':
 			$key = 'geo_affinity';

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -559,6 +559,17 @@ function wpcloud_client_ssh_user_update( int $wpcloud_site_id, string $user, str
 	return $response;
 }
 
+function wpcloud_client_ssh_disconnect_all_users( int $wpcloud_site_id): mixed {
+	$client_name = wpcloud_get_client_name();
+	return wpcloud_client_post( $wpcloud_site_id, "ssh-disconnect-all-users/$client_name/$wpcloud_site_id" );
+}
+
+function wpcloud_client_site_set_access_type( int $wpcloud_site_id, string $access_type): mixed {
+	$client_name = wpcloud_get_client_name();
+	return wpcloud_client_post( $wpcloud_site_id, "site-set-access-type/$client_name/$wpcloud_site_id/$access_type" );
+}
+
+
 function wpcloud_client_site_meta_keys(): array {
 	// @TODO move the labels to WPCLOUD_Site::get_meta_fields()
 	return [

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -541,6 +541,24 @@ function wpcloud_client_ssh_user_remove( int $wpcloud_site_id, string $user ): m
 	return wpcloud_client_post( $wpcloud_site_id, "ssh-user/$client_name/$wpcloud_site_id/remove/$user" );
 }
 
+function wpcloud_client_ssh_user_update( int $wpcloud_site_id, string $user, string $pkey = '', string|null $pass = null) : mixed {
+	$client_name = wpcloud_get_client_name();
+
+	$post = array(
+		'pkey' => $pkey,
+	);
+	if ( ! is_null( $pass ) ) {
+		$post['pass'] = $pass;
+	}
+
+	$response = wpcloud_client_post( $wpcloud_site_id, "ssh-user/$client_name/$wpcloud_site_id/update/$user", $post );
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	return $response;
+}
+
 function wpcloud_client_site_meta_keys(): array {
 	// @TODO move the labels to WPCLOUD_Site::get_meta_fields()
 	return [

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -566,7 +566,7 @@ function wpcloud_client_ssh_disconnect_all_users( int $wpcloud_site_id): mixed {
 
 function wpcloud_client_site_set_access_type( int $wpcloud_site_id, string $access_type): mixed {
 	$client_name = wpcloud_get_client_name();
-	return wpcloud_client_post( $wpcloud_site_id, "site-set-access-type/$client_name/$wpcloud_site_id/$access_type" );
+	return wpcloud_client_get( $wpcloud_site_id, "site-set-access-type/$client_name/$wpcloud_site_id/$access_type" );
 }
 
 


### PR DESCRIPTION
The ssh settings block allows for disconnecting all ssh connections to a site and switching the access type from ssh to sftp.

NOTE: I don't see a way to know if a site is set up for ssh or sftp to set the default toggle value. For now it will always be set to ssh, which might not be true, it's 50/50 😄 