### PR TITLE
Plugin: Fix password input name

### DIFF
--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -13,7 +8,7 @@ export default function SelectField( {
 	className,
 	onValueChange,
 } ) {
-	const { name, value } = attributes;
+	const { name, value, inputStyle, required } = attributes;
 	let { options } = attributes;
 
 	if (!options) {
@@ -23,13 +18,13 @@ export default function SelectField( {
 	return (
 		<div className="wpcloud-form-input--select--wrapper">
 			<select
-				className={ classNames(
-					className,
-					'wpcloud-station-form-input__select'
-				) }
+				className={ className }
 				aria-label={ __( 'Select' ) }
 				value={ value }
 				onChange={ ( event ) => onValueChange( event.target.value ) }
+				style={ inputStyle }
+				name={ name }
+				required={ required }
 			>
 				{ options.map( ( option, index ) => ( <option key={ index } value={ option.value }>{ option.label }</option> ) ) }
 			</select>

--- a/plugin/blocks/src/components/form-input/fields/text.js
+++ b/plugin/blocks/src/components/form-input/fields/text.js
@@ -13,7 +13,7 @@ export default function TextField( {
 	className,
 	onPlaceholderChange,
 } ) {
-	const { placeholder, required, type } = attributes;
+	const { placeholder, required, type, name } = attributes;
 
 	const controls = <></>;
 
@@ -32,7 +32,8 @@ export default function TextField( {
 				onChange={ ( event ) =>
 					onPlaceholderChange( event.target.value )
 				}
-				aria-required={ required }
+				aria-required={required}
+				name={name}
 			/>
 		</>
 	);

--- a/plugin/blocks/src/components/form-input/fields/text.js
+++ b/plugin/blocks/src/components/form-input/fields/text.js
@@ -1,40 +1,32 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+
 
 export default function TextField( {
 	attributes,
 	className,
 	onPlaceholderChange,
 } ) {
-	const { placeholder, required, type, name } = attributes;
-
-	const controls = <></>;
+	const { placeholder, required, type, name, uniqueId, inputStyle } = attributes;
 
 	const TagName = type === 'textarea' ? 'textarea' : 'input';
 	return (
-		<>
-			{ controls }
+
 			<TagName
 				type={ 'textarea' === type ? undefined : type }
-				className={ classNames(
-					className,
-					'wpcloud-block-form-input__input'
-				) }
+				className={ className }
 				aria-label={ __( 'Optional placeholder text' ) }
-				placeholder={ placeholder }
+				placeholder={ placeholder || undefined }
 				onChange={ ( event ) =>
 					onPlaceholderChange( event.target.value )
 				}
-				aria-required={required}
-				name={name}
+				name={ name }
+				id={ uniqueId }
+				style={ inputStyle }
+				required={ required }
+				aria-required={ required }
 			/>
-		</>
 	);
 }

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -35,15 +35,16 @@ if ( array_key_exists($name, $site_meta_options) ) {
 
 	if ( 'select' === $type ) {
 		$options = $site_meta_options[$name]['options'];
-
 		$options_html = '';
-		foreach ( $options as $value => $label ) {
-			$options_html .= sprintf(
-				'<option value="%s" %s>%s</option>',
-				esc_attr( $value ),
-				selected( $current_value, $value, false ),
-				esc_html( $label )
-			);
+		if ( ! is_wp_error( $options ) ) {
+			foreach ( $options as $value => $label ) {
+				$options_html .= sprintf(
+					'<option value="%s" %s>%s</option>',
+					esc_attr( $value ),
+					selected( $current_value, $value, false ),
+					esc_html( $label )
+				);
+			}
 		}
 
 		$regex = '/(<select[^>]*>)(?:\s*<option[^>]*>.*?<\/option>)*\s*(<\/select>)/';

--- a/plugin/blocks/src/components/form-input/save.js
+++ b/plugin/blocks/src/components/form-input/save.js
@@ -21,7 +21,7 @@ import { __unstableStripHTML as stripHTML } from '@wordpress/dom'; // eslint-dis
  * Internal dependencies
  */
 
-import Password from './fields/password';
+import { Text, Password, Select } from './fields';
 
 /**
  * Get the name attribute from a content string.
@@ -42,66 +42,18 @@ const getNameFromLabel = ( content ) => {
 	);
 };
 
-function renderSelect(
-	{ options, label, name, required },
-	inputClasses,
-	inputStyle
-) {
-	if ( ! options ) {
-		options = [ { label: `{ ${ name } }`, value: '' } ];
-	}
-	return (
-		<div class="wpcloud-form-input--select--wrapper">
-			<select
-				className={ classNames(
-					'wpcloud-station-form-input__select',
-					inputClasses
-				) }
-				style={ inputStyle }
-				name={ name || getNameFromLabel( label ) }
-				required={ required }
-				aria-required={ required }
-			>
-				{ options.map( ( option ) => (
-					<option key={ option.value } value={ option.value }>
-						{ option.label }
-					</option>
-				) ) }
-			</select>
-		</div>
-	);
-}
-
-function renderText(
-	{ type, name, label, required, placeholder, uniqueId },
-	inputClasses,
-	inputStyle
-) {
-	const TagName = 'textarea' === type ? 'textarea' : 'input';
-	return (
-		<TagName
-			className={ inputClasses }
-			type={ 'textarea' === type ? undefined : type }
-			name={ name || getNameFromLabel( label ) }
-			required={ required }
-			aria-required={ required }
-			placeholder={ placeholder || undefined }
-			style={inputStyle}
-			id={ uniqueId }
-		/>
-	);
-}
-
 function renderField( attributes ) {
 	const { type, displayAsToggle, submitOnChange } = attributes;
 
 	const borderProps = getBorderClassesAndStyles( attributes );
 	const colorProps = getColorClassesAndStyles( attributes );
 
-	const inputStyle = {
+	attributes.inputStyle = {
 		...borderProps.style,
 		...colorProps.style,
 	};
+
+	attributes.name = attributes.name || getNameFromLabel( attributes.label );
 
 	const inputClasses = classNames(
 		'wpcloud-block-form-input__input',
@@ -117,8 +69,8 @@ function renderField( attributes ) {
 	}
 
 	return 'select' === type
-		? renderSelect( attributes, inputClasses, inputStyle )
-		: renderText( attributes, inputClasses, inputStyle );
+		? <Select attributes={attributes} className={inputClasses} />
+		: <Text attributes={attributes} className={inputClasses} />;
 }
 
 


### PR DESCRIPTION
Adds back the `name` attribute to the password input. 
Also use common input components for save.js