### PR TITLE
Plugin: Add edge cache support

### DIFF
--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -113,7 +113,7 @@ function wpcloud_block_admin_enqueue_scripts(): void {
 			'wpcloud.wpVersions=' . wp_json_encode( wpcloud_block_available_wp_versions() ) . ';' .
 			'wpcloud.dataCenters=' . wp_json_encode( wpcloud_block_available_datacenters_options() ) . ';' .
 			'wpcloud.linkableSiteDetails=' . wp_json_encode( WPCloud_Site::get_linkable_detail_options() ) . ';' .
-			'wpcloud.siteMetaOptions=' . wp_json_encode( WPCloud_Site::get_meta_options() ) . ';' .
+			'wpcloud.siteMutableOptions=' . wp_json_encode( WPCloud_Site::get_mutable_options() ) . ';' .
 			'wpcloud.siteMetaFields=' . wp_json_encode( WPCloud_Site::get_meta_fields() ) . ';'
 		);
 	}

--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -114,7 +114,7 @@ function wpcloud_block_admin_enqueue_scripts(): void {
 			'wpcloud.dataCenters=' . wp_json_encode( wpcloud_block_available_datacenters_options() ) . ';' .
 			'wpcloud.linkableSiteDetails=' . wp_json_encode( WPCloud_Site::get_linkable_detail_options() ) . ';' .
 			'wpcloud.siteMutableOptions=' . wp_json_encode( WPCloud_Site::get_mutable_options() ) . ';' .
-			'wpcloud.siteMetaFields=' . wp_json_encode( WPCloud_Site::get_meta_fields() ) . ';'
+			'wpcloud.siteMutableFields=' . wp_json_encode( WPCloud_Site::get_mutable_fields() ) . ';'
 		);
 	}
 }

--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -103,6 +103,7 @@ function wpcloud_block_available_wp_versions(): array {
  */
 function wpcloud_block_admin_enqueue_scripts(): void {
 	if ( ! wp_doing_ajax() ) {
+		wp_register_script( 'wpcloud-blocks-site-form', '', array(), '1.0.0', true );
 		wp_enqueue_script( 'wpcloud-blocks-site-form' );
 		wp_add_inline_script(
 			'wpcloud-blocks-site-form',

--- a/plugin/blocks/src/components/controls/site/detailSelect.js
+++ b/plugin/blocks/src/components/controls/site/detailSelect.js
@@ -14,7 +14,7 @@ export default function DetailSelect( {
 	let options = [{ value: '', label: '-'}];
 	let optionData = {};
 	if ('input' === context) {
-		optionData = window.wpcloud?.siteMetaFields || {};
+		optionData = window.wpcloud?.siteMutableFields || {};
 	} else {
 		optionData = window.wpcloud?.siteDetails || {};
 	}

--- a/plugin/blocks/src/components/controls/site/detailSelect.js
+++ b/plugin/blocks/src/components/controls/site/detailSelect.js
@@ -19,8 +19,8 @@ export default function DetailSelect( {
 		optionData = window.wpcloud?.siteDetails || {};
 	}
 
-	for (const [key, value] of Object.entries(optionData)) {
-		options.push( { value: key, label: value } );
+	for (const [ key, value ] of Object.entries(optionData)) {
+		options.push({ value: key, label: value.label || value }  );
 	}
 
 	return (
@@ -28,12 +28,13 @@ export default function DetailSelect( {
 			label={ __( 'Select a site detail' ) }
 			value={ name }
 			options={ options }
-			onChange={ ( newName ) => {
-				const label = optionData[ newName ] || newName;
+			onChange={(newName) => {
+				const label = optionData[ newName ].label || optionData[ newName ] || newName;
 				setAttributes( {
 					name: newName,
 					label,
 					metadata: { name: label },
+					options: optionData[ newName ].options || [],
 				} );
 				onChange && onChange( newName );
 			} }

--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -9,11 +9,18 @@ export default function SelectField( {
 	onValueChange,
 } ) {
 	const { name, value, inputStyle, required } = attributes;
-	let { options } = attributes;
+	let { options = { label: `{ ${name} } `, value: '' } } = attributes;
 
-	if (!options) {
-		options = [{ label: `{ ${name} } `, value: '' }];
+	// Loading options from the backend can have the form { value: 'label' }
+	if ( ! Array.isArray( options ) ) {
+		const optionData = [];
+		for ( const [ key, value ] of Object.entries( options ) ) {
+			optionData.push( { value: key, label: value } );
+		}
+		options = optionData;
 	}
+
+
 
 	return (
 		<div className="wpcloud-form-input--select--wrapper">

--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -20,8 +20,6 @@ export default function SelectField( {
 		options = optionData;
 	}
 
-
-
 	return (
 		<div className="wpcloud-form-input--select--wrapper">
 			<select

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -26,7 +26,7 @@ if ( ! $allowed ) {
 $content = apply_filters( 'wpcloud_block_form_render_field_' . $name, $content, $attributes, $block );
 $content = apply_filters( 'wpcloud_block_form_render_field', $content, $attributes, $block );
 
-$site_meta_options = WPCloud_Site::get_meta_options();
+$site_meta_options = WPCloud_Site::get_mutable_options();
 
 if ( array_key_exists( $name, $site_meta_options ) ) {
 	$current_value = wpcloud_get_site_detail( get_the_ID(), $name );

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -26,9 +26,9 @@ if ( ! $allowed ) {
 $content = apply_filters( 'wpcloud_block_form_render_field_' . $name, $content, $attributes, $block );
 $content = apply_filters( 'wpcloud_block_form_render_field', $content, $attributes, $block );
 
-$site_meta_options = WPCloud_Site::get_mutable_options();
+$site_mutable_options = WPCloud_Site::get_mutable_options();
 
-if ( array_key_exists( $name, $site_meta_options ) ) {
+if ( array_key_exists( $name, $site_mutable_options ) ) {
 	$current_value = wpcloud_get_site_detail( get_the_ID(), $name );
 	if ( 'ssh_port' === $name ) {
 		error_log( 'WP Cloud: ' . $current_value );
@@ -38,11 +38,11 @@ if ( array_key_exists( $name, $site_meta_options ) ) {
 		$current_value = '';
 	}
 	if ( ! $current_value ) {
-		$current_value = $site_meta_options[ $name ]['default'] ?? '';
+		$current_value = $site_mutable_options[ $name ]['default'] ?? '';
 	}
 
 	if ( 'select' === $input_type ) {
-		$options      = $site_meta_options[ $name ]['options'];
+		$options      = $site_mutable_options[ $name ]['options'];
 		$options_html = '';
 		if ( ! is_wp_error( $options ) ) {
 			foreach ( $options as $value => $label ) {

--- a/plugin/blocks/src/components/form-input/render.php
+++ b/plugin/blocks/src/components/form-input/render.php
@@ -43,13 +43,20 @@ if ( array_key_exists( $name, $site_mutable_options ) ) {
 
 	if ( 'select' === $input_type ) {
 		$options      = $site_mutable_options[ $name ]['options'];
+		$aliases      = $site_mutable_options[ $name ]['option_aliases'] ?? array();
 		$options_html = '';
 		if ( ! is_wp_error( $options ) ) {
 			foreach ( $options as $value => $label ) {
+
+				$selected = selected( $current_value, $value, false );
+				// check for option aliases.
+				if ( ! $selected && array_key_exists( $value, $aliases ) ) {
+					$selected = selected( $current_value, $aliases[ $value ], false );
+				}
 				$options_html .= sprintf(
 					'<option value="%s" %s>%s</option>',
 					esc_attr( $value ),
-					selected( $current_value, $value, false ),
+					esc_attr( $selected ),
 					esc_html( $label )
 				);
 			}

--- a/plugin/blocks/src/site-update/index.js
+++ b/plugin/blocks/src/site-update/index.js
@@ -10,14 +10,14 @@ import { InnerBlocks } from '@wordpress/block-editor';
  */
 import metadata from './block.json';
 
-const metaOptions = window.wpcloud?.siteMetaOptions || {};
+const mutableOptions = window.wpcloud?.siteMutableOptions || {};
 
 function addInputTemplate( name, label ) {
-	const options = metaOptions[ name ]?.options;
+	const options = mutableOptions[ name ]?.options;
 
 	// If there is hin text we will use that as the label
 
-	const hintText = metaOptions[ name ]?.hint;
+	const hintText = mutableOptions[ name ]?.hint;
 	let hint = null;
 	if ( hintText ) {
 		hint = [
@@ -54,7 +54,7 @@ function addInputTemplate( name, label ) {
 		];
 	}
 
-	const type = metaOptions[ name ]?.type || 'text';
+	const type = mutableOptions[ name ]?.type || 'text';
 
 	const inputAttributes = {
 		type,

--- a/plugin/custom-post-types/wpcloud-site.php
+++ b/plugin/custom-post-types/wpcloud-site.php
@@ -348,6 +348,24 @@ function wpcloud_get_site_detail( int|WP_Post $post, string $key, ): mixed {
 			// @TODO: Confirm that this is always the case, it appears that the port will be 2223 for ssh and 2221 for sftp
 			return 2223 === $ssh_port;
 
+		case 'edge_cache':
+			$result = wpcloud_client_edge_cache_status( $wpcloud_site_id );
+			if ( is_wp_error( $result ) ) {
+				error_log( $result->get_error_message() );
+				return '';
+			}
+			switch ( $result->status ) {
+				case 0:
+					return __( 'Disabled', 'wpcloud' );
+				case 1:
+					return __( 'Enabled', 'wpcloud' );
+				case 2:
+					return __( 'DDoS', 'wpcloud' );
+				default:
+					return __( 'Unknown', 'wpcloud' );
+			}
+			return '';
+
 		case 'data_center':
 			$key = 'geo_affinity';
 			// Fallthrough intentional to set the result.

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -414,6 +414,10 @@ class WPCLOUD_Site {
 					'off'   => __( 'Off' ),
 					'purge' => __( 'Purge' ),
 				),
+				'option_aliases' => array(
+					'on'  => __( 'Enabled', 'wpcloud' ),
+					'off' => __( 'Disabled', 'wpcloud' ),
+				),
 				'default' => '',
 				'hint'    => __( 'Change the edge cache status. Either `on`, `off` or `purge`' ),
 			),

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -223,15 +223,6 @@ class WPCLOUD_Site {
 		return apply_filters( 'wpcloud_site_detail_options', $options );
 	}
 	/**
-	 * Get the meta keys for a WPCLOUD_Site.
-	 *
-	 * @return array
-	 */
-	public static function get_meta_fields(): array {
-		return wpcloud_client_site_meta_keys();
-	}
-
-	/**
 	 * Get mutable option keys
 	 *
 	 * @return array

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -214,12 +214,13 @@ class WPCLOUD_Site {
 			'ssl_info'         => __( 'SSL Info' ),
 			'wp_admin_url'     => __( 'WP Admin URL' ),
 			'site_ssh_user'    => __( 'Site SSH User' ),
+			'edge_cache'       => __( 'Edge Cache' ),
 
 			// These are read only meta fields.
 			'max_space_quota'  => __( 'Max Space Quota' ),
 			'space_used'       => __( 'Space Used' ),
 		);
-		return do_filter( 'wpcloud_site_detail_options', $options );
+		return apply_filters( 'wpcloud_site_detail_options', $options );
 	}
 	/**
 	 * Get the meta keys for a WPCLOUD_Site.
@@ -228,6 +229,21 @@ class WPCLOUD_Site {
 	 */
 	public static function get_meta_fields(): array {
 		return wpcloud_client_site_meta_keys();
+	}
+
+	/**
+	 * Get mutable option keys
+	 *
+	 * @return array
+	 */
+	public static function get_mutable_fields(): array {
+		$fields = array();
+		foreach ( self::get_mutable_options() as $key => $option ) {
+			if ( isset( $option['label'] ) ) {
+				$fields[ $key ] = $option['label'];
+			}
+		}
+		return $fields;
 	}
 
 	/**
@@ -242,6 +258,7 @@ class WPCLOUD_Site {
 		$options = array(
 			// db_charset and db_collate should be paired ?
 			'db_charset'           => array(
+				'label'   => __( 'DB Charset' ),
 				'type'    => 'select',
 				'options' => array(
 					'latin1 ' => 'latin1',
@@ -253,6 +270,7 @@ class WPCLOUD_Site {
 			),
 
 			'db_collate'           => array(
+				'label'   => __( 'DB Collate' ),
 				'type'    => 'select',
 				'options' => array(
 					'latin1_swedish_ci'  => 'latin1_swedish_ci',
@@ -264,6 +282,7 @@ class WPCLOUD_Site {
 			),
 
 			'suspended'            => array(
+				'label'   => __( 'Suspended' ),
 				'type'    => 'select',
 				'options' => array(
 					''    => '',
@@ -277,6 +296,7 @@ class WPCLOUD_Site {
 			),
 
 			'suspend_after'        => array(
+				'label'   => __( 'Suspend After' ),
 				'type'    => 'text',
 				'options' => null,
 				'default' => false,
@@ -284,6 +304,7 @@ class WPCLOUD_Site {
 			),
 
 			'php_version'          => array(
+				'label'   => __( 'PHP Version' ),
 				'type'    => 'select',
 				'options' => wpcloud_client_php_versions_available(),
 				'default' => '',
@@ -291,6 +312,7 @@ class WPCLOUD_Site {
 			),
 
 			'wp_version'           => array(
+				'label'   => __( 'WP Version' ),
 				'type'    => 'select',
 				'options' => array(
 					'latest'   => __( 'latest' ),
@@ -302,24 +324,28 @@ class WPCLOUD_Site {
 			),
 
 			'do_not_delete'        => array(
+				'label'   => __( 'Do Not Delete' ),
 				'type'    => 'checkbox',
 				'default' => false,
 				'hint'    => __( 'Prevent a site from begin deleted. This can be useful in some cases. For example, you might wish to preserve a site while it is being reviewed for Terms of Service violations.' ),
 			),
 
 			'space_quota'          => array(
+				'label'   => __( 'Space Quota' ),
 				'type'    => 'text',
 				'default' => 0,
 				'hint'    => __( 'Sets the space quota for a site. Values should be in gigabytes.' ),
 			),
 
 			'photon_subsizes'      => array(
+				'label'   => __( 'Photon Subsizes' ),
 				'type'    => 'checkbox',
 				'default' => false,
 				'hint'    => __( 'Controls whether WP skips generating intermediate image files when an image is uploaded. The platform is able to satisfy requests for intermediate image files whether or not they exist, so sites can save disk space by not creating them. When the a site web server receives a request for a non-existent intermediate image file, it proxies the request to Photon which responds with the intermediate image size.' ),
 			),
 
 			'privacy_model'        => array(
+				'label'   => __( 'Privacy Model' ),
 				'type'    => 'select',
 				'options' => array(
 					''           => '',
@@ -330,6 +356,7 @@ class WPCLOUD_Site {
 			),
 
 			'static_file_404'      => array(
+				'label'   => __( 'Static File 404' ),
 				'type'    => 'select',
 				'options' => array(
 					'lightweight' => __( 'Lightweight' ),
@@ -340,6 +367,7 @@ class WPCLOUD_Site {
 			),
 
 			'default_php_conns'    => array(
+				'label'   => __( 'Default PHP Conns' ),
 				'type'    => 'select',
 				'options' => range( 2, 10 ),
 				'default' => 0,
@@ -347,12 +375,14 @@ class WPCLOUD_Site {
 			),
 
 			'burst_php_conns'      => array(
+				'label'   => __( 'Burst PHP Conns' ),
 				'type'    => 'checkbox',
 				'default' => false,
 				'hint'    => __( 'Enable burst for sites with fewer than 10 default_php_conns. 0 or absent when default_php_conns < 10 means burst is disabled, 1 means burst is enabled.' ),
 			),
 
 			'php_fs_permissions'   => array(
+				'label'   => __( 'PHP FS Permissions' ),
 				'type'    => 'select',
 				'options' => array(
 					'RW'       => __( 'Read/Write' ),
@@ -364,15 +394,28 @@ class WPCLOUD_Site {
 			),
 
 			'canonicalize_aliases' => array(
+				'label'   => __( 'Canonicalize Aliases' ),
 				'type'    => 'checkbox',
 				'default' => true,
 				'hint'    => __( 'May be used to change whether a sites domain aliases redirect (default, "true") to the sites primary domain name or are served directly (when set to "false")' ),
 			),
 
 			'site_access_with_ssh' => array(
+				'label'   => __( 'Site Access With SSH' ),
 				'type'    => 'checkbox',
 				'default' => false,
 				'hint'    => __( 'Site access is via SFTP by default. Enabling allows access via SSH' ),
+			),
+			'edge_cache'           => array(
+				'label'   => __( 'Edge Cache' ),
+				'type'    => 'select',
+				'options' => array(
+					'on'    => __( 'On' ),
+					'off'   => __( 'Off' ),
+					'purge' => __( 'Purge' ),
+				),
+				'default' => '',
+				'hint'    => __( 'Change the edge cache status. Either `on`, `off` or `purge`' ),
 			),
 		);
 		return apply_filters( 'wpcloud_site_mutable_options', $options );

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -240,7 +240,7 @@ class WPCLOUD_Site {
 		$fields = array();
 		foreach ( self::get_mutable_options() as $key => $option ) {
 			if ( isset( $option['label'] ) ) {
-				$fields[ $key ] = $option['label'];
+				$fields[ $key ] = $option;
 			}
 		}
 		return $fields;

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -187,7 +187,7 @@ class WPCLOUD_Site {
 	 * @return array The detail options
 	 */
 	public static function get_detail_options(): array {
-		return array(
+		$options = array(
 			'site_name'        => __( 'Site Name' ), // only used locally.
 			'site_owner_id'    => __( 'Site Owner ID' ), // only used locally.
 			'domain_name'      => __( 'Domain Name' ),
@@ -219,6 +219,7 @@ class WPCLOUD_Site {
 			'max_space_quota'  => __( 'Max Space Quota' ),
 			'space_used'       => __( 'Space Used' ),
 		);
+		return do_filter( 'wpcloud_site_detail_options', $options );
 	}
 	/**
 	 * Get the meta keys for a WPCLOUD_Site.
@@ -237,8 +238,8 @@ class WPCLOUD_Site {
 	 *
 	 * @return array
 	 */
-	public static function get_meta_options(): array {
-		return array(
+	public static function get_mutable_options(): array {
+		$options = array(
 			// db_charset and db_collate should be paired ?
 			'db_charset'           => array(
 				'type'    => 'select',
@@ -367,12 +368,14 @@ class WPCLOUD_Site {
 				'default' => true,
 				'hint'    => __( 'May be used to change whether a sites domain aliases redirect (default, "true") to the sites primary domain name or are served directly (when set to "false")' ),
 			),
+
 			'site_access_with_ssh' => array(
 				'type'    => 'checkbox',
 				'default' => false,
 				'hint'    => __( 'Site access is via SFTP by default. Enabling allows access via SSH' ),
 			),
 		);
+		return apply_filters( 'wpcloud_site_mutable_options', $options );
 	}
 
 	/**

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -610,7 +610,6 @@ function wpcloud_client_site_set_access_type( int $wpcloud_site_id, string $acce
  * @return array The meta keys for a site.
  */
 function wpcloud_client_site_meta_keys(): array {
-	// @TODO move the labels to WPCLOUD_Site::get_meta_fields()
 	return array(
 		'db_charset'           => __( 'DB Charset' ),
 		'db_collate'           => __( 'DB Collate' ),

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -773,9 +773,9 @@ function wpcloud_client_edge_cache_status( int $wpcloud_site_id ): stdClass|WP_E
  * @param integer $wpcloud_site_id The WP Cloud Site ID.
  * @param string  $action          The action to take. 'on', 'off', or 'purge'.
  *
- * @return stdClass|WP_Error Edge cache status on success. WP_Error on failure.
+ * @return array|WP_Error Edge cache status on success. WP_Error on failure.
  */
-function wpcloud_client_edge_cache_update( int $wpcloud_site_id, string $action ): stdClass|WP_Error {
+function wpcloud_client_edge_cache_update( int $wpcloud_site_id, string $action ): array|WP_Error {
 	return wpcloud_client_post( $wpcloud_site_id, "edge-cache/$wpcloud_site_id/$action" );
 }
 /**

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -758,6 +758,28 @@ function wpcloud_client_remove_client_meta( string $key ): stdClass|WP_Error {
 }
 
 /**
+ * Get the status of the edge cache for a site.
+ *
+ * @param integer $wpcloud_site_id The WP Cloud Site ID.
+ *
+ * @return stdClass|WP_Error Edge cache status on success. WP_Error on failure.
+ */
+function wpcloud_client_edge_cache_status( int $wpcloud_site_id ): stdClass|WP_Error {
+	return wpcloud_client_get( $wpcloud_site_id, "edge-cache/$wpcloud_site_id" );
+}
+
+/**
+ * Update the edge cache for a site.
+ *
+ * @param integer $wpcloud_site_id The WP Cloud Site ID.
+ * @param string  $action          The action to take. 'on', 'off', or 'purge'.
+ *
+ * @return stdClass|WP_Error Edge cache status on success. WP_Error on failure.
+ */
+function wpcloud_client_edge_cache_update( int $wpcloud_site_id, string $action ): stdClass|WP_Error {
+	return wpcloud_client_post( $wpcloud_site_id, "edge-cache/$wpcloud_site_id/$action" );
+}
+/**
  * Get the status of a job.
  *
  * @param integer $job_id The job id for which to get the status.

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -611,24 +611,24 @@ function wpcloud_client_site_set_access_type( int $wpcloud_site_id, string $acce
  */
 function wpcloud_client_site_meta_keys(): array {
 	return array(
-		'db_charset'           => __( 'DB Charset' ),
-		'db_collate'           => __( 'DB Collate' ),
-		'suspended'            => __( 'Suspended Status Code' ),
-		'suspend_after'        => __( 'Suspend After' ),
-		'php_version'          => __( 'PHP Version' ),
-		'wp_version'           => __( 'WP Version' ),
-		'do_not_delete'        => __( 'Do Not Delete' ),
-		'db_file_size'         => __( 'DB File Size' ),
-		'space_quota'          => __( 'Space Quota' ),
-		'max_space_quota'      => __( 'Max Space Quota (Gigabytes)' ),
-		'photon_subsizes'      => __( 'Photon Subsizes' ),
-		'privacy_model'        => __( 'Privacy Model' ),
-		'static_file_404'      => __( 'Static File 404' ),
-		'default_php_conns'    => __( 'Default PHP Connections' ),
-		'burst_php_conns'      => __( 'Burst PHP Connections' ),
-		'php_fs_permissions'   => __( 'PHP FS Permissions' ),
-		'canonicalize_aliases' => __( 'Canonicalize Aliases' ),
-		'ssh_port'             => __( 'SSH Port' ),
+		'db_charset',
+		'db_collate',
+		'suspended',
+		'suspend_after',
+		'php_version',
+		'wp_version',
+		'do_not_delete',
+		'db_file_size',
+		'space_quota',
+		'max_space_quota',
+		'photon_subsizes',
+		'privacy_model',
+		'static_file_404',
+		'default_php_conns',
+		'burst_php_conns',
+		'php_fs_permissions',
+		'canonicalize_aliases',
+		'ssh_port',
 	);
 }
 /**
@@ -644,7 +644,7 @@ function wpcloud_client_site_meta_keys(): array {
  * @return mixed|WP_Error Response body on success. WP_Error on failure.
  */
 function wpcloud_client_update_site_meta( int $wpcloud_site_id, string $key, string|null $value ): mixed {
-	if ( ! array_key_exists( $key, wpcloud_client_site_meta_keys() ) ) {
+	if ( ! in_array( $key, wpcloud_client_site_meta_keys() ) ) {
 		return new WP_Error( 'bad_request', 'Invalid meta key', array( 'status' => 400 ) );
 	}
 
@@ -668,7 +668,7 @@ function wpcloud_client_update_site_meta( int $wpcloud_site_id, string $key, str
  * @return mixed|WP_Error Response body on success. WP_Error on failure.
  */
 function wpcloud_client_delete_site_meta( int $wpcloud_site_id, string $key ): mixed {
-	if ( ! array_key_exists( $key, wpcloud_client_site_meta_keys() ) ) {
+	if ( ! in_array( $key, wpcloud_client_site_meta_keys() ) ) {
 		return new WP_Error( 'bad_request', 'Invalid meta key', array( 'status' => 400 ) );
 	}
 
@@ -687,7 +687,7 @@ function wpcloud_client_delete_site_meta( int $wpcloud_site_id, string $key ): m
  */
 function wpcloud_client_get_site_meta( int $wpcloud_site_id, string $key, bool $use_cache = true ): stdClass|WP_Error {
 	$get_meta = function () use ( $wpcloud_site_id, $key ) {
-		if ( ! array_key_exists( $key, wpcloud_client_site_meta_keys() ) ) {
+		if ( ! in_array( $key, wpcloud_client_site_meta_keys() ) ) {
 			return new WP_Error( 'bad_request', 'Invalid meta key', array( 'status' => 400 ) );
 		}
 


### PR DESCRIPTION
- Adds endpoint to client
- Adds block support in the `site_detail` and `form_input` blocks
- Updates form inputs to render select options from the site mutable options config
- Add filters to the site options