### PR TITLE
Plugin: remove php 7.4

### DIFF
--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -439,6 +439,8 @@ function wpcloud_client_php_versions_available( bool $descending = false, bool $
 			},
 			array()
 		);
+		// Remove PHP 7.4 from the list.
+		unset( $result['7.4'] );
 
 		if ( $descending ) {
 			arsort( $result );


### PR DESCRIPTION
7.4 is no longer available for new sites but is still on the platform till we migrate all sites. 
New sites should not be created with 7.4