### PR TITLE
Plugin: Add alias verification flow

### DIFF
--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -42,7 +42,7 @@ function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
 		if ( str_contains( $message, 'TXT' ) ) {
 			$response['needsVerification'] = true;
 			$response['site_alias']        = $data['site_alias'];
-			doAction( 'wpcloud_site_alias_needs_verification', $data['site_alias'], $wpcloud_site_id );
+			do_action( 'wpcloud_site_alias_needs_verification', $data['site_alias'], $wpcloud_site_id );
 		}
 		$response['success'] = false;
 		$response['message'] = $added->get_error_message();

--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -38,6 +38,11 @@ function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
 	$added = wpcloud_client_site_domain_alias_add( $wpcloud_site_id, $data['site_alias'] );
 
 	if ( is_wp_error( $added ) ) {
+		$message = $added->get_error_message();
+		if ( str_contains( $message, 'TXT' ) ) {
+			$response['needsVerification'] = true;
+			$response['site_alias']        = $data['site_alias'];
+		}
 		$response['success'] = false;
 		$response['message'] = $added->get_error_message();
 		$response['status']  = 400;

--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -42,6 +42,7 @@ function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
 		if ( str_contains( $message, 'TXT' ) ) {
 			$response['needsVerification'] = true;
 			$response['site_alias']        = $data['site_alias'];
+			doAction( 'wpcloud_site_alias_needs_verification', $data['site_alias'], $wpcloud_site_id );
 		}
 		$response['success'] = false;
 		$response['message'] = $added->get_error_message();

--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -55,3 +55,21 @@ function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
 	return $response;
 }
 add_filter( 'wpcloud_form_process_site_alias_add', 'wpcloud_block_form_site_alias_add_handler', 10, 2 );
+
+
+
+/**
+ * Process the form data for verifying a site alias.
+ *
+ * @param array $response The response data.
+ * @param array $data The form data.
+ * @return array The response data.
+ */
+function wpcloud_block_form_request_txt_verification_handler( $response, $data ) {
+
+	$response['message'] = 'TXT verification request sent successfully.';
+	$response['code']    = '1234567890';
+
+	return $response;
+}
+add_filter( 'wpcloud_form_process_request_txt_verification', 'wpcloud_block_form_request_txt_verification_handler', 10, 2 );

--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -56,7 +56,16 @@ function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
 }
 add_filter( 'wpcloud_form_process_site_alias_add', 'wpcloud_block_form_site_alias_add_handler', 10, 2 );
 
-
+/**
+ * Add the required fields for the domain verification forms.
+ *
+ * @param array $fields The form fields.
+ * @return array The form fields.
+ */
+function wpcloud_block_form_request_txt_verification_fields( array $fields ) {
+	return array_merge( $fields, array( 'domain_name' ) );
+}
+add_filter( 'wpcloud_block_form_submitted_fields_request_txt_verification', 'wpcloud_block_form_request_txt_verification_fields' );
 
 /**
  * Process the form data for verifying a site alias.
@@ -67,8 +76,17 @@ add_filter( 'wpcloud_form_process_site_alias_add', 'wpcloud_block_form_site_alia
  */
 function wpcloud_block_form_request_txt_verification_handler( $response, $data ) {
 
+	$verification_code = wpcloud_client_domain_verification_record( $data['domain_name'] ?? '' );
+
+	if ( is_wp_error( $verification_code ) ) {
+		$response['success'] = false;
+		$response['message'] = $verification_code->get_error_message();
+		$response['status']  = 409;
+		return $response;
+	}
+
 	$response['message'] = 'TXT verification request sent successfully.';
-	$response['code']    = '1234567890';
+	$response['code']    = $verification_code;
 
 	return $response;
 }

--- a/plugin/blocks/src/components/site-alias-add/view.js
+++ b/plugin/blocks/src/components/site-alias-add/view.js
@@ -24,4 +24,28 @@
 		'site_alias_add',
 		onSiteAliasAdd
 	);
+
+
+	wpcloud.hooks.addAction(
+		'wpcloud_form_response_request_txt_verification',
+		'request_txt_verification',
+		(result, form) => {
+			if ( ! result.success ) {
+				alert( result.message ); // eslint-disable-line no-alert, no-undef
+				return;
+			}
+			console.log(form);
+			const code = result.code;
+			const actions = form.closest('.wpcloud-alias-actions');
+			const detail = actions.querySelector('.site-alias-verification-code');
+			detail.dataset.clipboardPattern = code;
+
+			actions.querySelector('.wpcloud-copy-to-clipboard')?.addEventListener('click', wpcloud.copyToClipboard);
+
+			const value = detail.querySelector('.wpcloud-block-site-detail__value');
+			value.textContent = `Verification code: ${code}`;
+
+			detail.classList.remove('display-none');
+		}
+	)
 } )( window.wpcloud );

--- a/plugin/blocks/src/components/site-alias-add/view.js
+++ b/plugin/blocks/src/components/site-alias-add/view.js
@@ -3,19 +3,20 @@
 	 * Handle the response from the site alias add form.
 	 * @param {Object} result - The response from the server.
 	 */
-	function onSiteAliasAdd( result ) {
-		if ( ! result.success ) {
-			alert( result.message ); // eslint-disable-line no-alert, no-undef
-			return;
+	function onSiteAliasAdd(result) {
+
+		if ( !result.success && !result.needsVerification ) {
+				alert( result.message ); // eslint-disable-line no-alert, no-undef
+				return;
 		}
-		// @TODO: do something with the success ?
+
 		const newAliasInput = document.querySelector(
 			'.wpcloud-block-form--site-alias-add input[name=site_alias]'
 		);
 		if ( newAliasInput ) {
 			newAliasInput.value = '';
 		}
-		wpcloud.hooks.doAction( 'wpcloud_alias_added', result.site_alias );
+		wpcloud.hooks.doAction( 'wpcloud_alias_added', result.site_alias, result.needsVerification || false );
 	}
 
 	wpcloud.hooks.addAction(

--- a/plugin/blocks/src/components/site-alias-add/view.js
+++ b/plugin/blocks/src/components/site-alias-add/view.js
@@ -26,12 +26,23 @@
 	);
 
 
+	wpcloud.hooks.addFilter(
+		'wpcloud_form_data_request_txt_verification',
+		'request_txt_verification',
+		(data, form) => {
+			const alias = form.closest('[data-site-alias]')
+				?.dataset.siteAlias;
+			data.domain_name = alias;
+			return data;
+		}
+	)
+
 	wpcloud.hooks.addAction(
 		'wpcloud_form_response_request_txt_verification',
 		'request_txt_verification',
 		(result, form) => {
-			if ( ! result.success ) {
-				alert( result.message ); // eslint-disable-line no-alert, no-undef
+			if (!result.success) {
+				alert(result.message); // eslint-disable-line no-alert, no-undef
 				return;
 			}
 			console.log(form);
@@ -43,9 +54,9 @@
 			actions.querySelector('.wpcloud-copy-to-clipboard')?.addEventListener('click', wpcloud.copyToClipboard);
 
 			const value = detail.querySelector('.wpcloud-block-site-detail__value');
-			value.textContent = `Verification code: ${code}`;
+			value.textContent = `Verification code`;
 
 			detail.classList.remove('display-none');
 		}
-	)
+	);
 } )( window.wpcloud );

--- a/plugin/blocks/src/components/site-alias-list/edit.js
+++ b/plugin/blocks/src/components/site-alias-list/edit.js
@@ -121,110 +121,189 @@ export default function Edit() {
 								},
 							},
 						],
-
-						[
-							'wpcloud/more-menu',
+						['core/group',
 							{
-								showMenu: false,
+								className: 'wpcloud-alias-actions',
+								style: {
+									layout: {
+										selfStretch: 'fit',
+										flexSize: null,
+									},
+									spacing: {
+										padding: { right: '0', left: '0' },
+										margin: { top: '0', bottom: '0' },
+										blockGap: '0',
+									},
+								},
+								layout: {
+									type: 'flex',
+									flexWrap: 'wrap',
+									justifyContent: 'left',
+								},
+								metadata: {
+									name: 'Alias Actions',
+								},
 							},
 							[
 								[
-									'core/heading',
+									'wpcloud/site-detail',
 									{
-										level: 4,
+										label: 'Verification Code',
+										hideLabel: true,
+										showCopyButton: true,
+										metadata: {
+											name: 'Verification Code',
+										},
 										className:
-											'wpcloud-site-list-menu__title',
-										content: __( 'Domain Options' ),
+											'site-alias-verification-code display-none',
 									},
 								],
-								[
-									'wpcloud/form',
+								['wpcloud/icon',
 									{
-										ajax: true,
-										wpcloudAction:
-											'site_alias_make_primary',
-										inline: true,
-										className:
-											'wpcloud-block-site-alias-list--make-primary wpcloud-more-menu__row',
+										icon: 'warning',
+										className: 'alias-warning display-none',
+									},
+								],
+								[ 'wpcloud/more-menu',
+									{
+										showMenu: false,
 									},
 									[
 										[
-											'wpcloud/icon',
-											{ icon: 'starEmpty' },
-										],
-										[
-											'wpcloud/form-input',
+											'core/heading',
 											{
-												type: 'hidden',
-												name: 'site_alias',
+												level: 4,
+												className:
+													'wpcloud-site-list-menu__title',
+												content: __( 'Domain Options' ),
 											},
 										],
 										[
-											'wpcloud/button',
+											'wpcloud/form',
 											{
-												label: __( 'Make Primary' ),
-												style: 'text',
-												type: 'submit'
+												ajax: true,
+												wpcloudAction:
+													'site_alias_make_primary',
+												inline: true,
+												className:
+													'wpcloud-block-site-alias-list--make-primary wpcloud-more-menu__row',
+												metadata: {
+													name: __( 'Make Primary' ),
+												}
 											},
+											[
+												[
+													'wpcloud/icon',
+													{ icon: 'starEmpty' },
+												],
+												[
+													'wpcloud/form-input',
+													{
+														type: 'hidden',
+														name: 'site_alias',
+													},
+												],
+												[
+													'wpcloud/button',
+													{
+														label: __( 'Make Primary' ),
+														style: 'text',
+														type: 'submit'
+													},
+												],
+											],
 										],
-									],
+										[
+											'wpcloud/form',
+											{
+												ajax: true,
+												wpcloudAction:
+													'site_alias_remove',
+												inline: true,
+												className:
+													'wpcloud-block-site-alias-list--remove wpcloud-more-menu__row',
+												metadata: {
+													name: __( 'Remove Domain' ),
+												}
+											},
+											[
+												[ 'wpcloud/icon', { icon: 'trash' } ],
+												[
+													'wpcloud/form-input',
+													{
+														type: 'hidden',
+														name: 'site_alias',
+													},
+												],
+												[
+													'wpcloud/button',
+													{
+														label: __( 'Remove Domain' ),
+														style: 'text',
+														type: 'submit'
+													},
+												],
+											],
+										],
+										[
+											'wpcloud/form',
+											{
+												wpcloudAction: 'request_txt_verification',
+												inline: true,
+												className:
+													'display-none wpcloud-block-form-request_txt_verification wpcloud-more-menu__row',
+												metadata: {
+													name: __('Request TXT'),
+												},
+											},
+											[
+												[
+													'wpcloud/icon',
+													{ icon: 'warning' },
+												],
+												[
+													'wpcloud/button',
+													{
+														label: __( 'Request TXT' ),
+														style: 'text',
+														type: 'submit',
+														isPrimary: false
+													},
+												],
+											],
+										],
+										[
+											'wpcloud/form',
+											{
+												ajax: true,
+												wpcloudAction: 'retry_ssl',
+												inline: true,
+												className:
+													'display-none wpcloud-block-form-retry-ssl wpcloud-more-menu__row',
+												metadata: {
+													name: __('Retry SSL'),
+												},
+											},
+											[
+												[
+													'wpcloud/icon',
+													{ icon: 'warning' },
+												],
+												[
+													'wpcloud/button',
+													{
+														label: __( 'Retry SSL' ),
+														style: 'text',
+														type: 'submit',
+														isPrimary: false
+													},
+												],
+											],
+										]
+									]
 								],
-								[
-									'wpcloud/form',
-									{
-										ajax: true,
-										wpcloudAction:
-											'site_alias_remove',
-										inline: true,
-										className:
-											'wpcloud-block-site-alias-list--remove wpcloud-more-menu__row',
-									},
-									[
-										[ 'wpcloud/icon', { icon: 'trash' } ],
-										[
-											'wpcloud/form-input',
-											{
-												type: 'hidden',
-												name: 'site_alias',
-											},
-										],
-										[
-											'wpcloud/button',
-											{
-												label: __( 'Remove Domain' ),
-												style: 'text',
-												type: 'submit'
-											},
-										],
-									],
-								],
-								[
-									'wpcloud/form',
-									{
-										ajax: true,
-										wpcloudAction: 'retry_ssl',
-										inline: true,
-										className:
-											'display-none wpcloud-block-form-retry-ssl wpcloud-more-menu__row',
-									},
-									[
-										[
-											'wpcloud/icon',
-											{ icon: 'warning' },
-										],
-										[
-											'wpcloud/button',
-											{
-												label: __( 'Retry SSL' ),
-												style: 'text',
-												type: 'submit',
-												isPrimary: false
-											},
-										],
-									],
-								]
 							]
-						],
+						]
 					],
 				],
 			],

--- a/plugin/blocks/src/components/site-alias-list/render.php
+++ b/plugin/blocks/src/components/site-alias-list/render.php
@@ -14,6 +14,7 @@ if ( ! $wpcloud_site_id ) {
 	return;
 }
 $site_aliases = wpcloud_client_site_domain_alias_list( $wpcloud_site_id );
+$site_aliases = applyFilters( 'wpcloud_site_aliases', $site_aliases, $wpcloud_site_id );
 
 if ( is_wp_error( $site_aliases ) ) {
 	error_log( 'WP Cloud Site Alias Block: Error fetching site aliases.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/plugin/blocks/src/components/site-alias-list/render.php
+++ b/plugin/blocks/src/components/site-alias-list/render.php
@@ -14,7 +14,7 @@ if ( ! $wpcloud_site_id ) {
 	return;
 }
 $site_aliases = wpcloud_client_site_domain_alias_list( $wpcloud_site_id );
-$site_aliases = applyFilters( 'wpcloud_site_aliases', $site_aliases, $wpcloud_site_id );
+$site_aliases = applyFilters( 'wpcloud_render_site_aliases', $site_aliases, $wpcloud_site_id );
 
 if ( is_wp_error( $site_aliases ) ) {
 	error_log( 'WP Cloud Site Alias Block: Error fetching site aliases.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/plugin/blocks/src/components/site-alias-list/render.php
+++ b/plugin/blocks/src/components/site-alias-list/render.php
@@ -14,7 +14,7 @@ if ( ! $wpcloud_site_id ) {
 	return;
 }
 $site_aliases = wpcloud_client_site_domain_alias_list( $wpcloud_site_id );
-$site_aliases = applyFilters( 'wpcloud_render_site_aliases', $site_aliases, $wpcloud_site_id );
+$site_aliases = apply_filters( 'wpcloud_render_site_aliases', $site_aliases, $wpcloud_site_id );
 
 if ( is_wp_error( $site_aliases ) ) {
 	error_log( 'WP Cloud Site Alias Block: Error fetching site aliases.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/plugin/blocks/src/components/site-alias-list/view.js
+++ b/plugin/blocks/src/components/site-alias-list/view.js
@@ -37,7 +37,7 @@
 		row.classList.add( 'wpcloud-hide' );
 	}
 
-	function onSiteAliasAdded( alias ) {
+	function onSiteAliasAdded( alias, needsVerification ) {
 		const row = aliasList
 			.querySelector(
 				'.wpcloud-block-site-alias-list__row[style*="display:none"]'
@@ -55,9 +55,18 @@
 
 		// Set up the new forms
 		newRow.querySelectorAll( 'form' ).forEach( ( form ) => {
-			form.querySelector( 'input[name=site_alias]' ).value = alias;
-			wpcloud.bindFormHandler( form );
-		} );
+			const inputSiteAlias = form.querySelector('input[name=site_alias]');
+			if (inputSiteAlias) {
+				inputSiteAlias.value = alias;
+			}
+			wpcloud.bindFormHandler(form);
+		});
+
+		if (needsVerification) {
+			['.wpcloud-block-form-request_txt_verification', '.alias-warning'].forEach((selector) => {
+				newRow.querySelector(selector).classList.remove('display-none');
+			});
+		}
 
 
 		const aliasValueNode = newRow.querySelector('.wpcloud-block-site-detail__value');

--- a/plugin/blocks/src/components/site-alias-list/view.js
+++ b/plugin/blocks/src/components/site-alias-list/view.js
@@ -203,7 +203,8 @@
 		const response = await fetch(`/wp-json/wpcloud/v1/domains/ssl-status?domain=${domain}`);
 		const result = await response.json();
 		if ( result.success && ! result.valid ) {
-			form.classList.remove( 'display-none' );
+			form.classList.remove('display-none');
+			form.closest('.wpcloud-block-site-alias-list__row').querySelector('.alias-warning')?.classList.remove('display-none');
 		} else {
 			form.classList.add( 'display-none' );
 		}

--- a/plugin/blocks/src/components/site-detail/view.js
+++ b/plugin/blocks/src/components/site-detail/view.js
@@ -29,7 +29,6 @@
 
 		try {
 			await navigator.clipboard.writeText( text );
-			//alert( 'Copied to clipboard' );
 		} catch ( error ) {
 			console.error( error.message );
 		}

--- a/plugin/blocks/src/site-domains/view.js
+++ b/plugin/blocks/src/site-domains/view.js
@@ -3,8 +3,7 @@
 		'wpcloud_form_response_site_alias_add',
 		'site_alias_add',
 		(result) => {
-			if (!result.success) {
-				alert(result.message); // eslint-disable-line no-alert, no-undef
+			if (!result.success && !result.needsVerification) {
 				return;
 			}
 			const form = document.querySelector(

--- a/plugin/controllers/class-wpcloud-domains-controller.php
+++ b/plugin/controllers/class-wpcloud-domains-controller.php
@@ -38,8 +38,9 @@ if ( ! class_exists( 'WPCLOUD_Domains_Controller' ) ) {
 				'/' . $this->rest_base . '/ssl-status',
 				array(
 					array(
-						'methods'  => WP_REST_Server::READABLE,
-						'callback' => array( $this, 'get_ssl_status' ),
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_ssl_status' ),
+						'permission_callback' => '__return_true',
 					),
 				)
 			);

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -72,7 +72,7 @@ function wpcloud_client_domain_validate( ?int $wpcloud_site_id, string $domain )
 	// Otherwise, return the error.
 	if ( is_wp_error( $response ) ) {
 		if ( ! strpos( $response->get_error_message(), 'Domain mapping record already exists' ) ) {
-			$domain_verification_record = wpcloud_client_domain_verification_record( $wpcloud_site_id, $domain );
+			$domain_verification_record = wpcloud_client_domain_verification_record( $domain );
 
 			return new WP_Error(
 				'conflict',
@@ -93,15 +93,14 @@ function wpcloud_client_domain_validate( ?int $wpcloud_site_id, string $domain )
 /**
  * Retrieve the domain verification record for a domain.
  *
- * @param integer|null $wpcloud_site_id Optional. The WP Cloud Site ID.
- * @param string       $domain          The domain for which to get the domain verification record.
+ * @param string $domain          The domain for which to get the domain verification record.
  *
  * @return string|WP_Error Domain verification record. WP_Error on error.
  */
-function wpcloud_client_domain_verification_record( ?int $wpcloud_site_id, string $domain ): mixed {
+function wpcloud_client_domain_verification_record( string $domain ): mixed {
 	$client_name = wpcloud_get_client_name();
 
-	return wpcloud_client_get( $wpcloud_site_id, "get-domain-verification-code/{$client_name}/{$domain}" );
+	return wpcloud_client_get( null, "get-domain-verification-code/{$client_name}/{$domain}" );
 }
 
 /**


### PR DESCRIPTION
This adds a flow to fetch a verification code if the added site alias is already in use.

Screens:

![Screen Recording 2024-08-15 at 12 17 26 AM](https://github.com/user-attachments/assets/183e4553-168d-497b-82f5-35292ae3671a)

NOTE: This does not store the failed domain. For now a user will have to add the domain to then request the TXT record. 
This this does add  two hooks to save and load domains from the local site
`wpcloud_site_alias_needs_verification` is fired when a domain needs verification
`wpcloud_render_site_aliases` allows for adding to the list of site aliases fetched from the API

