### PR TITLE
Plugin: refactor how forms get the site id.

### DIFF
--- a/plugin/blocks/src/components/site-alias-add/index.php
+++ b/plugin/blocks/src/components/site-alias-add/index.php
@@ -27,22 +27,14 @@ add_filter( 'wpcloud_block_form_submitted_fields_site_alias_add', 'wpcloud_block
  * @return array The response data.
  */
 function wpcloud_block_form_site_alias_add_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-
-	$added = wpcloud_client_site_domain_alias_add( $wpcloud_site_id, $data['site_alias'] );
+	$added = wpcloud_client_site_domain_alias_add( $data['wpcloud_site_id'], $data['site_alias'] );
 
 	if ( is_wp_error( $added ) ) {
 		$message = $added->get_error_message();
 		if ( str_contains( $message, 'TXT' ) ) {
 			$response['needsVerification'] = true;
 			$response['site_alias']        = $data['site_alias'];
-			do_action( 'wpcloud_site_alias_needs_verification', $data['site_alias'], $wpcloud_site_id );
+			do_action( 'wpcloud_site_alias_needs_verification', $data['site_alias'], $data['wpcloud_site_id'] );
 		}
 		$response['success'] = false;
 		$response['message'] = $added->get_error_message();

--- a/plugin/blocks/src/components/ssh-user-form/index.php
+++ b/plugin/blocks/src/components/ssh-user-form/index.php
@@ -26,14 +26,6 @@ add_filter( 'wpcloud_block_form_submitted_fields_site_ssh_user_update', 'wpcloud
  * @return array The response data.
  */
 function wpcloud_block_form_site_ssh_user_add_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-
 	// Use current user if user is not set.
 	if ( ! isset( $data['user'] ) ) {
 		$user         = wp_get_current_user();
@@ -41,7 +33,7 @@ function wpcloud_block_form_site_ssh_user_add_handler( $response, $data ) {
 	}
 
 	$user   = sanitize_user( $data['user'] );
-	$result = wpcloud_client_ssh_user_add( $wpcloud_site_id, uniqid( $user ), $data['pkey'], $data['pass'] );
+	$result = wpcloud_client_ssh_user_add( $data['wpcloud_site_id'], uniqid( $user ), $data['pkey'], $data['pass'] );
 
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;
@@ -65,14 +57,7 @@ add_filter( 'wpcloud_form_process_site_ssh_user_add', 'wpcloud_block_form_site_s
  * @return array The response data.
  */
 function wpcloud_block_form_site_ssh_user_update_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-	$result = wpcloud_client_ssh_user_update( $wpcloud_site_id, $data['user'], $data['pkey'], $data['pass'] );
+	$result = wpcloud_client_ssh_user_update( $data['wpcloud_site_id'], $data['user'], $data['pkey'], $data['pass'] );
 
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;

--- a/plugin/blocks/src/components/ssh-user-list/index.php
+++ b/plugin/blocks/src/components/ssh-user-list/index.php
@@ -25,16 +25,8 @@ add_filter( 'wpcloud_block_form_submitted_fields_site_ssh_user_remove', 'wpcloud
  * @return array The response data.
  */
 function wpcloud_block_form__site_ssh_user_remove_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-
 	$user   = sanitize_user( $data['ssh_user'] );
-	$result = wpcloud_client_ssh_user_remove( $wpcloud_site_id, $user );
+	$result = wpcloud_client_ssh_user_remove( $data['wpcloud_site_id'], $user );
 
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;

--- a/plugin/blocks/src/site-defensive-mode/index.php
+++ b/plugin/blocks/src/site-defensive-mode/index.php
@@ -50,8 +50,7 @@ add_filter( 'wpcloud_form_process_defensive_mode_update', 'wpcloud_block_form_de
  * @return array The response.
  */
 function wpcloud_block_form_defensive_mode_disable_handler( $response, $data ) {
-	$wpcloud_site_id = $data['wpcloud_site_id'];
-	$result          = wpcloud_client_defensive_mode_update( $wpcloud_site_id );
+	$result = wpcloud_client_defensive_mode_update( $data['wpcloud_site_id'] );
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;
 		$response['message'] = $result->get_error_message();

--- a/plugin/blocks/src/site-ssh-settings/index.php
+++ b/plugin/blocks/src/site-ssh-settings/index.php
@@ -25,17 +25,9 @@ add_filter( 'wpcloud_block_form_submitted_fields_site_access_type', 'wpcloud_blo
  * @return array The response.
  */
 function wpcloud_block_form_site_access_type_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-
 	$site_access_type = '1' === $data['site_access_with_ssh'] ? 'ssh' : 'sftp';
 
-	$result = wpcloud_client_site_set_access_type( $wpcloud_site_id, $site_access_type );
+	$result = wpcloud_client_site_set_access_type( $data['wpcloud_site_id'], $site_access_type );
 
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;
@@ -58,15 +50,7 @@ add_filter( 'wpcloud_form_process_site_access_type', 'wpcloud_block_form_site_ac
  * @return array The response.
  */
 function wpcloud_block_form_site_ssh_disconnect_all_users_handler( $response, $data ) {
-	$wpcloud_site_id = get_post_meta( $data['site_id'], 'wpcloud_site_id', true );
-
-	if ( ! $wpcloud_site_id ) {
-		$response['message'] = 'Site not found.';
-		$response['status']  = 400;
-		return $response;
-	}
-
-	$result = wpcloud_client_ssh_disconnect_all_users( $wpcloud_site_id );
+	$result = wpcloud_client_ssh_disconnect_all_users( $data['wpcloud_site_id'] );
 
 	if ( is_wp_error( $result ) ) {
 		$response['success'] = false;


### PR DESCRIPTION
if the form is on a wpcloud site page then the `wpcloud_site_id` is available in the form data. There is no need to fetch the id from the post meta directly. 