### PR TITLE
Plugin: Fix site details block

### DIFF
--- a/plugin/blocks/src/site-details/render.php
+++ b/plugin/blocks/src/site-details/render.php
@@ -5,11 +5,6 @@
  * @package wpcloud
  */
 
-if ( ! is_wpcloud_site_post() ) {
-	return;
-}
-
-/* Return early if the user is not an admin and the block is admin only */
 if ( $attributes['adminOnly'] && ! current_user_can( 'manage_options' ) ) {
 	return;
 }


### PR DESCRIPTION
The site details block shouldn't be limited to site pages since on it's own it's not dependent on a site.