### PR TITLE
Plugin: headstart redux

### DIFF
--- a/plugin/admin/includes/wpcloud-headstart.php
+++ b/plugin/admin/includes/wpcloud-headstart.php
@@ -127,11 +127,11 @@ function wpcloud_headstart(  WP_Upgrader_Skin $headstart_skin = new WPCloud_Quit
 	$core_pages = array(
 		'login'    => array(
 			'title'   => 'Login',
-			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/page-login"} /-->',
+			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/form-login"} /-->',
 		),
 		'add-site' => array(
 			'title'   => 'Add Site',
-			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/page-add-site"} /-->',
+			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/form-add-site"} /-->',
 		),
 	);
 

--- a/plugin/admin/includes/wpcloud-headstart.php
+++ b/plugin/admin/includes/wpcloud-headstart.php
@@ -1,0 +1,193 @@
+<?php // phpcs:disable Generic.Files.nameConventions.UpperCaseConstantName.NotFound
+/**
+ * WP Cloud Station Headstart.
+ *
+ * @package wpcloud-station
+ * @subpackage headstart
+ */
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+declare( strict_types = 1 );
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/class-theme-upgrader.php';
+
+if ( ! defined( 'WP_CLOUD_STATION_REPO' ) ) {
+	define( 'WP_CLOUD_STATION_REPO', 'https://github.com/automattic/wpcloud-station' );
+}
+
+/**
+ * WP Cloud Skin for the upgrader.
+ */
+class WPCloud_Quiet_Skin extends WP_Upgrader_Skin {
+	/**
+	 * Stub
+	 *
+	 * @param string $message The string to output.
+	 * @param mixed  ...$args The arguments to pass to the string.
+	 */
+	public function feedback( $message, ...$args ): string {
+		// Silence is golden.
+		return '';
+	}
+
+	/**
+	 * Stub
+	 */
+	public function header(): string {
+		// Silence is golden.
+		return '';
+	}
+
+	/**
+	 * Stub
+	 */
+	public function footer(): string {
+		// Silence is golden.
+		return '';
+	}
+}
+
+/**
+ * WP Cloud Debug Skin for the headstart.
+ */
+class WPCloud_Debug_Skin extends WPCloud_Quiet_Skin {
+
+	/**
+	 * Output the feedback.
+	 *
+	 * @param string $message The string to output.
+	 * @param mixed  ...$args The arguments to pass to the string.
+	 */
+	public function feedback( $message, ...$args ): string {
+		error_log( $message ); // phpcs:ignore
+		return '';
+	}
+}
+
+/**
+ * Install the WP Cloud Station theme.
+ *
+ * @param WP_Upgrader_Skin $headstart_skin The skin to use for the installation.
+ * @return true|WP_Error True if headstart succeeded, WP_Error on failure.
+ */
+function wpcloud_headstart(  WP_Upgrader_Skin $headstart_skin = new WPCloud_Quite_Skin() ): true|WP_Error { // phpcs:ignore
+
+	// Install the demo theme.
+	$available_themes = wp_get_themes();
+
+	$installed = false;
+	foreach ( $available_themes as $theme ) {
+
+		if ( str_contains( $theme->get( 'Name' ), 'WP Cloud Station' ) ) {
+			$installed = true;
+			break;
+		}
+	}
+
+	if ( ! $installed ) {
+		$headstart_skin->feedback( 'Installing WP Cloud Station theme...' );
+		$package   = WP_CLOUD_STATION_REPO . '/releases/latest/download/wpcloud-station-theme.zip ';
+		$up_grader = new Theme_Upgrader( $headstart_skin );
+		$installed = $up_grader->install( $package );
+
+		if ( is_wp_error( $installed ) ) {
+			$headstart_skin->feedback( $installed->get_error_message() );
+		}
+
+		if ( $installed ) {
+			switch_theme( 'wpcloud-station-theme' );
+		} else {
+			$headstart_skin->feedback( 'Failed to install theme.' );
+			return new WP_Error( 'install_failed', 'Failed to install theme.' );
+		}
+	}
+
+	// Configure permalinks (will likely not work if running from wp cli).
+	global $wp_rewrite;
+
+	$permalink_structure = '/%postname%/';
+	$wp_rewrite->set_permalink_structure( $permalink_structure );
+	$wp_rewrite->flush_rules( true );
+
+	// Add the private category.
+	$wpcloud_private_cat = get_category_by_slug( WPCLOUD_PRIVATE_CATEGORY );
+	if ( ! $wpcloud_private_cat ) {
+		$wpcloud_private_cat = wp_insert_term(
+			'WP Cloud Private Page',
+			'category',
+			array(
+				'description' => 'Private category for WP Cloud specific pages.',
+				'slug'        => WPCLOUD_PRIVATE_CATEGORY,
+			)
+		);
+	}
+
+	$core_pages = array(
+		'login'    => array(
+			'title'   => 'Login',
+			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/page-login"} /-->',
+		),
+		'add-site' => array(
+			'title'   => 'Add Site',
+			'content' => '<!-- wp:pattern {"slug":"wpcloud-station/page-add-site"} /-->',
+		),
+	);
+
+	$query = new WP_Query(
+		array(
+			'cat'           => $wpcloud_private_cat->term_id,
+			'post_type'     => 'any',
+			'post_name__in' => array_keys( $core_pages ),
+		)
+	);
+
+	$post_names = array_map( fn( $post ) => $post->post_name, $query->get_posts() );
+
+	foreach ( $core_pages as $page_name => $args ) {
+		if ( ! in_array( $page_name, $post_names, true ) ) {
+			$headstart_skin->feedback( 'Creating "' . $args['title'] . '" page...' );
+			$page_id = wpcloud_headstart_insert_page( array_merge( $args, array( 'name' => $page_name ) ) );
+			if ( is_wp_error( $page_id ) ) {
+				$headstart_skin->feedback( $page_id->get_error_message() );
+			}
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Create insert a page
+ *
+ * @param array $args The arguments for the core pages.
+ * @return int|WP_Error The page ID or WP_Error on failure.
+ */
+function wpcloud_headstart_insert_page( array $args ): int|WP_Error {
+	$post_args = array(
+		'post_title'   => $args['title'] ?? '',
+		'post_content' => $args['content'] ?? '',
+		'post_status'  => 'publish',
+		'post_type'    => 'page',
+		'post_name'    => $args['name'] ?? '',
+	);
+
+	$post_category = $args['category'] ?? array();
+
+	$wpcloud_private_cat = get_category_by_slug( WPCLOUD_PRIVATE_CATEGORY );
+	if ( $wpcloud_private_cat ) {
+		$post_category[] = $wpcloud_private_cat->term_id;
+	}
+	$post_args['post_category'] = $post_category;
+	return wp_insert_post( $post_args );
+}
+
+add_action(
+	'update_option',
+	function ( $option ) {
+		if ( 'wpcloud_settings' === $option ) {
+			wpcloud_headstart( new WPCloud_Debug_Skin() );
+		}
+	},
+);

--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -7,6 +7,8 @@
 
 declare( strict_types = 1 );
 
+require_once 'includes/wpcloud-headstart.php';
+
 /**
  * Get the available themes.
  *
@@ -190,6 +192,21 @@ function wpcloud_settings_init(): void {
 			'description'         => __( 'Enable caching of common client requests to reduce the number of requests to the WP Cloud API and speed up page loads. The cache is stored in memory per request.' ),
 			'type'                => 'checkbox',
 			'checked'             => get_option( 'wpcloud_settings', array() )['client_cache'] ?? false,
+		)
+	);
+
+	add_settings_field(
+		'wpcloud_field_headstart',
+		__( 'Headstart Set Up', 'wpcloud' ),
+		'wpcloud_field_input_cb',
+		'wpcloud',
+		'wpcloud_section_settings',
+		array(
+			'label_for'           => 'wpcloud_headstart',
+			'class'               => 'wpcloud_row',
+			'type'                => 'checkbox',
+			'wpcloud_custom_data' => 'custom',
+			'description'         => __( 'Run the headstart script to setup the demo site. The script will not delete or overwrite any existing pages or settings so it\'s safe to run multiple times.' ),
 		)
 	);
 }

--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -8,6 +8,11 @@
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
 
 require_once __DIR__ . '/wpcloud-client.php';
+require_once __DIR__ . '/../admin/includes/wpcloud-headstart.php';
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/class-theme-upgrader.php';
 
 /**
  * WP Cloud CLI
@@ -741,6 +746,20 @@ class WPCloud_CLI_Client extends WPCloud_CLI {
 		self::log_result( wpcloud_client_php_versions_available() );
 		self::log( '%GData centers:' );
 		self::log_result( wpcloud_client_data_centers_available() );
+	}
+
+	/**
+	 * Run the headstart.
+	 *
+	 * @param array $args The arguments.
+	 * @param array $switches The switches.
+	 */
+	public function headstart( $args, $switches ) {
+		$result = wpcloud_headstart( new WPCloud_CLI_Skin() );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		WP_CLI::success( 'Headstart installed' );
 	}
 }
 

--- a/theme/patterns/form-add-site.php
+++ b/theme/patterns/form-add-site.php
@@ -4,8 +4,6 @@
  * Slug: wpcloud-station/page-add-site
  * Categories: wpcloud_forms
  * Keywords: starter
- * Blocks: wpcloud/site-create
- * Post Types: page
  * Description: Add new site form.
  */
 ?>

--- a/theme/patterns/form-add-site.php
+++ b/theme/patterns/form-add-site.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Title: Add Site Form
- * Slug: wpcloud-station/page-add-site
+ * Slug: wpcloud-station/form-add-site
  * Categories: wpcloud_forms
  * Keywords: starter
  * Description: Add new site form.

--- a/theme/patterns/form-login.php
+++ b/theme/patterns/form-login.php
@@ -1,11 +1,9 @@
 <?php
 /**
  * Title: Login Form
- * Slug: wpcloud-station/page-login
+ * Slug: wpcloud-station/form-login
  * Categories: wpcloud_forms
  * Keywords: starter
- * Blocks: wpcloud/login
- * Post Types: page
  * Description: Login form.
  */
 ?>


### PR DESCRIPTION
Add back a basic headstart.
This new version now pulls the content for the core pages from the theme patterns. This makes it easier to update when any of the blocks change.

It's also now idempotent so it's safe to run multiple times.