### PR TITLE
Plugin: Add API health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 *.zip
 
 /vendor/
+/build/

--- a/plugin/admin/assets/js/src/index.js
+++ b/plugin/admin/assets/js/src/index.js
@@ -1,12 +1,12 @@
 
-(function (wp, wpcloud ) {
-	if ( !wp || !wp.data || !wpcloud ) {
+(function ( { wp, wpcloud } ) {
+	if (!wp || !wpcloud ) {
 		return;
 	}
 	if (!wpcloud.apiConnected) {
 		wp.data.dispatch('core/notices').createNotice(
-			'warning',
-			'You are not connected to the WP Cloud API. Station requires a valid API connection to function properly.',
+			'error',
+			'You are not connected to the WP Cloud API. Station requires a valid API connection to function properly.', // Text string to display.
 			{
 				isDismissible: false,
 				actions: [
@@ -18,4 +18,4 @@
 			}
 		);
 	}
-} )( window.wp, window.wpcloud );
+})( window );

--- a/plugin/admin/assets/js/src/index.js
+++ b/plugin/admin/assets/js/src/index.js
@@ -1,0 +1,21 @@
+
+(function (wp, wpcloud ) {
+	if ( !wp || !wp.data || !wpcloud ) {
+		return;
+	}
+	if (!wpcloud.apiConnected) {
+		wp.data.dispatch('core/notices').createNotice(
+			'warning',
+			'You are not connected to the WP Cloud API. Station requires a valid API connection to function properly.',
+			{
+				isDismissible: false,
+				actions: [
+					{
+						url: '/wp-admin/admin.php?page=wpcloud_admin_settings',
+						label: 'WP Cloud Settings',
+					},
+				],
+			}
+		);
+	}
+} )( window.wp, window.wpcloud );

--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -541,3 +541,17 @@ function cc_mime_types( $mimes ) {
 	return $mimes;
 }
 add_filter( 'upload_mimes', 'cc_mime_types' );
+
+
+/**
+ * Enqueue the admin styles
+ *
+ * @return void
+ */
+add_action(
+	'admin_enqueue_scripts',
+	function () {
+		$config = require_once plugin_dir_path( __FILE__ ) . 'assets/js/build/index.asset.php';
+		wp_enqueue_script( 'wpcloud-admin', plugin_dir_url( __FILE__ ) . 'assets/js/build/index.js', $config['dependencies'], $config['version'], true );
+	}
+);

--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -8,6 +8,8 @@
 declare( strict_types = 1 );
 
 require_once 'includes/wpcloud-headstart.php';
+$wpcloud_request_api_status = wpcloud_client_test_status();
+$wpcloud_api_healthy        = is_wp_error( $wpcloud_request_api_status ) ? false : true;
 
 /**
  * Get the available themes.
@@ -67,6 +69,8 @@ function wpcloud_settings_sanitize( $input ) {
  * @return void
  */
 function wpcloud_settings_init(): void {
+	global $wpcloud_api_healthy;
+
 	register_setting( 'wpcloud', 'wpcloud_settings', 'wpcloud_settings_sanitize' );
 
 	add_settings_section(
@@ -113,6 +117,7 @@ function wpcloud_settings_init(): void {
 			'wpcloud_custom_data' => 'custom',
 			'default'             => '',
 			'description'         => __( 'The default domain to use for new sites. Each site will use this root domain with the site name as the subdomain. If left empty a unique subdomain will be generated for each site.' ),
+			'disabled'            => ! $wpcloud_api_healthy,
 		)
 	);
 
@@ -127,6 +132,7 @@ function wpcloud_settings_init(): void {
 			'class'           => 'wpcloud_row',
 			'description'     => __( 'The URL to send site creation events to. This can be used to trigger actions on site creation.' ),
 			'client_meta_key' => 'webhook_url',
+			'disabled'        => ! $wpcloud_api_healthy,
 		)
 	);
 
@@ -161,6 +167,7 @@ function wpcloud_settings_init(): void {
 			'description'         => __( 'The default theme to install on new sites.' ),
 			'items'               => $themes,
 			'default'             => array_keys( $themes )[0],
+			'disabled'            => ! $wpcloud_api_healthy,
 		)
 	);
 
@@ -176,6 +183,7 @@ function wpcloud_settings_init(): void {
 			'wpcloud_custom_data' => 'custom',
 			'description'         => __( 'Plugins available to install or activate with new installs. ' ),
 			'items'               => wpcloud_admin_get_available_plugins(),
+			'disabled'            => ! $wpcloud_api_healthy,
 		)
 	);
 
@@ -191,7 +199,8 @@ function wpcloud_settings_init(): void {
 			'wpcloud_custom_data' => 'custom',
 			'description'         => __( 'Enable caching of common client requests to reduce the number of requests to the WP Cloud API and speed up page loads. The cache is stored in memory per request.' ),
 			'type'                => 'checkbox',
-			'checked'             => get_option( 'wpcloud_settings', array() )['client_cache'] ?? false,
+			'checked'             => get_option( 'wpcloud_settings', array() )['client_cache'] ?? true,
+			'disabled'            => ! $wpcloud_api_healthy,
 		)
 	);
 
@@ -207,6 +216,7 @@ function wpcloud_settings_init(): void {
 			'type'                => 'checkbox',
 			'wpcloud_custom_data' => 'custom',
 			'description'         => __( 'Run the headstart script to setup the demo site. The script will not delete or overwrite any existing pages or settings so it\'s safe to run multiple times.' ),
+			'disabled'            => ! $wpcloud_api_healthy,
 		)
 	);
 }
@@ -279,7 +289,7 @@ function wpcloud_field_input_cb( array $args ): void {
 	if ( 'checkbox' === $type ) {
 		$value = '1';
 	}
-	$disabled = $args['disabled'] ?? false;
+	$disabled = $args['disabled'] ?? false ? ' disabled ' : '';
 	?>
 	<input
 			type="<?php echo esc_attr( $type ); ?>"
@@ -290,13 +300,10 @@ function wpcloud_field_input_cb( array $args ): void {
 			if ( 'checkbox' === $type && $checked ) {
 				echo ' checked '; }
 			?>
-			<?php
-			if ( $disabled ) {
-				echo ' disabled '; }
-			?>
+			<?php echo esc_attr( $disabled ); ?>
 		>
 	<?php if ( isset( $args['description'] ) ) { ?>
-		<p class="description"><?php echo esc_html( $args['description'] ); ?></p>
+		<p class="description <?php echo esc_attr( $disabled ); ?>"><?php echo esc_html( $args['description'] ); ?></p>
 		<?php
 	}
 	if ( isset( $args['error'] ) ) {
@@ -313,16 +320,13 @@ function wpcloud_field_input_cb( array $args ): void {
  * @return void.
  */
 function wpcloud_client_meta_field_input_cb( array $args ): void {
-	$meta_key = $args['client_meta_key'] ?? '';
-	$request  = wpcloud_client_get_client_meta( $meta_key );
-	if ( is_wp_error( $request ) ) {
-		// Let's ignore 404s.
-		if ( ! str_contains( $request->get_error_message(), 'Resource not found' ) ) {
-			$args['error'] = 'Warning: There was a issue retrieving the setting: ' . $request->get_error_message();
+	$disabled = $args['{disabled'] ?? false;
+	if ( ! $disabled ) {
+		$meta_key = $args['client_meta_key'] ?? '';
+		$request  = wpcloud_client_get_client_meta( $meta_key );
+		if ( ! is_wp_error( $request ) ) {
+			$args['value'] = $request->$meta_key;
 		}
-		error_log( $request->get_error_message() ); // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-	} else {
-		$args['value'] = $request->$meta_key;
 	}
 
 	wpcloud_field_input_cb( $args );
@@ -363,10 +367,11 @@ function wpcloud_field_select_cb( array $args ): void {
 	$default   = $args['default'] ?? '';
 	$value     = esc_attr( $options[ $label_for ] ?? $default );
 	$items     = $args['items'];
+	$disabled  = $args['disabled'] ?? false ? ' disabled ' : '';
 
 	// output the field.
 	?>
-	<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $label_for ); ?>">
+	<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $label_for ); ?>" <?php echo esc_attr( $disabled ); ?> >
 		<option value=''></option>
 	<?php
 	foreach ( $items as $item_value => $item_label ) {
@@ -376,7 +381,7 @@ function wpcloud_field_select_cb( array $args ): void {
 	?>
 	</select>
 	<?php if ( isset( $args['description'] ) ) { ?>
-		<p class="description"><?php echo esc_html( $args['description'] ); ?></p>
+		<p class="description <?php echo esc_attr( $disabled ); ?>"><?php echo esc_html( $args['description'] ); ?></p>
 		<?php
 	}
 }
@@ -391,6 +396,7 @@ function wpcloud_field_software_cb( array $args ): void {
 	$options   = get_option( 'wpcloud_settings' );
 	$label_for = esc_attr( $args['label_for'] );
 	$items     = $args['items'];
+	$disabled  = $args['disabled'] ?? false ? ' disabled ' : '';
 
 	// output the field.
 	echo '<table>';
@@ -400,10 +406,12 @@ function wpcloud_field_software_cb( array $args ): void {
 		?>
 		<tr>
 			<td style="padding: 5px;">
-				<label><?php echo esc_html( $item_label ); ?></label>
+				<label class="<?php echo esc_attr( $disabled ); ?>"><?php echo esc_html( $item_label ); ?></label>
 			</td>
 			<td style="padding: 5px;">
-				<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $name ); ?>">
+				<select name="<?php echo esc_attr( $name ); ?>" id="<?php echo esc_attr( $name ); ?>"
+				<?php echo esc_attr( $disabled ); ?>
+				>
 					<option value=""></option>
 					<option value="install" <?php echo ( 'install' === $value ) ? 'selected' : ''; ?>>Install</option>
 					<option value="activate" <?php echo ( 'activate' === $value ) ? 'selected' : ''; ?>>Activate</option>
@@ -415,7 +423,7 @@ function wpcloud_field_software_cb( array $args ): void {
 	echo '</table>';
 	if ( isset( $args['description'] ) ) {
 		?>
-		<p class="description"><?php echo esc_html( $args['description'] ); ?></p>
+		<p class="description <?php echo esc_attr( $disabled ); ?>"><?php echo esc_html( $args['description'] ); ?></p>
 		<?php
 	}
 }

--- a/plugin/admin/options.php
+++ b/plugin/admin/options.php
@@ -20,6 +20,13 @@ $wpcloud_api_error = '';
 if ( ! $wpcloud_api_healthy ) {
 	$wpcloud_api_error = $wpcloud_request_api_status->get_error_message();
 	$ip_error          = str_contains( $wpcloud_api_error, 'not allowed' );
+} else {
+	$client_ips_request = wpcloud_client_domain_ip_addresses( null );
+	if ( is_wp_error( $client_ips_request ) ) {
+		$client_ips = $client_ips_request;
+	} else {
+		$client_ips = ( (array) $client_ips_request )['ips'] ?? array();
+	}
 }
 
 ?>
@@ -86,6 +93,28 @@ if ( ! $wpcloud_api_healthy ) {
 				<?php esc_html_e( 'Return back to this page after correcting the API issues to continue configuring Station.' ); ?>
 			</p>
 		</div>
+	<?php else : ?>
+		<h2>Details</h2>
+		<table class="form-table" role="presentation">
+			<tbody>
+				<?php if ( $client_ips ) : ?>
+				<tr class="wpcloud_row">
+					<th scope="row">
+						<label for="wpcloud_api_key">WP Cloud IP Address Range</label>
+					</th>
+					<td>
+					<?php if ( is_wp_error( $client_ips ) ) : ?>
+						<?php echo esc_html( $client_ips->get_error_message() ); ?>
+					<?php else : ?>
+						<?php foreach ( $client_ips as $ip ) : ?>
+							<?php echo esc_html( $ip ); ?>
+						<?php endforeach; ?>
+					<?php endif; ?>
+					</td>
+				</tr>
+				<?php endif; ?>
+			</tbody>
+		</table>
 	<?php endif; ?>
 
 
@@ -96,19 +125,3 @@ if ( ! $wpcloud_api_healthy ) {
 			submit_button( 'Save Settings' );
 			?>
 	</form>
-<h2>Details</h2>
-<table class="form-table" role="presentation">
-	<tbody>
-		<?php if ( $client_ips ) : ?>
-		<tr class="wpcloud_row">
-			<th scope="row">
-				<label for="wpcloud_api_key">WP Cloud IP Address Range</label>
-			</th>
-			<td>
-			<?php foreach ( $client_ips as $ip ) : ?>
-				<?php echo esc_html( $ip ); ?>
-			<?php endforeach; ?>
-			</td>
-		</tr>
-		<?php endif; ?>
-</tbody></table>

--- a/plugin/admin/options.php
+++ b/plugin/admin/options.php
@@ -10,6 +10,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 $client_ips = null;
 $server_ip  = filter_var( wp_unslash( $_SERVER['SERVER_ADDR'] ?? '' ), FILTER_VALIDATE_IP );
+$ip_error   = false;
+
+global $wpcloud_request_api_status;
+global $wpcloud_api_healthy;
+
+$wpcloud_api_error = '';
+
+if ( ! $wpcloud_api_healthy ) {
+	$wpcloud_api_error = $wpcloud_request_api_status->get_error_message();
+	$ip_error          = str_contains( $wpcloud_api_error, 'not allowed' );
+}
 
 ?>
 <style>
@@ -17,10 +28,67 @@ $server_ip  = filter_var( wp_unslash( $_SERVER['SERVER_ADDR'] ?? '' ), FILTER_VA
 		.description {
 			width: 400px;
 		}
+		.disabled {
+			opacity: 0.5;
+		}
+		.warning {
+			font-weight: bold;
+		}
+		ul {
+			list-style: disc;
+			padding-left: 40px;
+		}
 	}
 </style>
 <div class="wrap wp-cloud-settings">
 	<h1>WP Cloud</h1>
+	<?php if ( ! $wpcloud_api_healthy ) : ?>
+	</div>
+		<div class="notice notice-error" >
+			<h3>WP Cloud API is not healthy</h3>
+			<p>
+				<?php esc_attr_e( 'Your site is unable to connect to the WP Cloud API' ); ?>
+				<br />
+				<strong><?php esc_attr_e( 'Please check the following:' ); ?></strong>
+			</p>
+
+			<ul>
+			<?php if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) : ?>
+				<li>
+					<p>
+						<?php esc_attr_e( 'It appears you are trying to run Station on a WP Cloud site. For security reasons, WP Cloud sites are unable to connect to the WP Cloud API directly. ' ); ?>
+					</p>
+					<p>
+						<strong><?php esc_attr_e( 'Please install Station on a different platform.' ); ?></strong>
+					</p>
+				</li>
+			<?php else : ?>
+				<?php if ( $ip_error ) : ?>
+				<li>
+					<p>
+						<?php esc_attr_e( 'The WP Cloud API limits access by IP address.' ); ?>
+						<br/>
+						<?php esc_attr_e( 'The server IP address appears to be:' ); ?>
+					</p>
+					<ul><li><strong><?php echo esc_attr( $server_ip ); ?></strong></li></ul>
+					<p>
+						<?php esc_attr_e( 'Please verify and update the server IP address with your WP Cloud representative.' ); ?>
+				<?php else : ?>
+					<li>
+						<p>
+							<?php echo esc_attr( $wpcloud_api_error ); ?>
+						</p>
+					</li>
+				<?php endif; ?>
+			<?php endif; ?>
+			</ul>
+			<p>
+				<?php esc_html_e( 'Return back to this page after correcting the API issues to continue configuring Station.' ); ?>
+			</p>
+		</div>
+	<?php endif; ?>
+
+
 	<form action="options.php" method="post">
 			<?php
 			settings_fields( 'wpcloud' );
@@ -43,12 +111,4 @@ $server_ip  = filter_var( wp_unslash( $_SERVER['SERVER_ADDR'] ?? '' ), FILTER_VA
 			</td>
 		</tr>
 		<?php endif; ?>
-			<tr class="wpcloud_row">
-			<th scope="row">
-				<label for="wpcloud_api_key">Server IP Address</label>
-			</th>
-			<td>
-			<?php echo esc_html( $server_ip ); ?>
-			</td>
-		</tr>
 </tbody></table>

--- a/plugin/assets/js/build/index.asset.php
+++ b/plugin/assets/js/build/index.asset.php
@@ -1,1 +1,0 @@
-<?php return array('dependencies' => array('wp-hooks'), 'version' => '8919650fdb9651fab50e');

--- a/plugin/assets/js/build/index.js
+++ b/plugin/assets/js/build/index.js
@@ -1,1 +1,0 @@
-(()=>{"use strict";const o=window.wp.hooks;window.wpcloud=window.wpcloud||{},wpcloud.hooks=wpcloud.hooks||(0,o.createHooks)(),wpcloud.fadeOut=(o,s=1e3)=>{o.classList.contains("no-fade-out")||(o.style.transition=`opacity ${s}ms`,o.style.opacity=0,setTimeout((()=>{o.style.display="none"}),s))}})();

--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -101,8 +101,11 @@ function wpcloud_block_available_wp_versions(): array {
  *
  * @return void
  */
-function wpcloud_block_admin_enqueue_scripts(): void {
-	if ( ! wp_doing_ajax() ) {
+function wpcloud_block_admin_enqueue_scripts( $current_screen ): void {
+	if ( ! $current_screen instanceof WP_Screen ) {
+		return;
+	}
+	if ( $current_screen->is_block_editor() ) {
 		wp_register_script( 'wpcloud-blocks-site-form', '', array(), '1.0.0', true );
 		wp_enqueue_script( 'wpcloud-blocks-site-form' );
 		wp_add_inline_script(
@@ -114,8 +117,9 @@ function wpcloud_block_admin_enqueue_scripts(): void {
 			'wpcloud.dataCenters=' . wp_json_encode( wpcloud_block_available_datacenters_options() ) . ';' .
 			'wpcloud.linkableSiteDetails=' . wp_json_encode( WPCloud_Site::get_linkable_detail_options() ) . ';' .
 			'wpcloud.siteMutableOptions=' . wp_json_encode( WPCloud_Site::get_mutable_options() ) . ';' .
-			'wpcloud.siteMutableFields=' . wp_json_encode( WPCloud_Site::get_mutable_fields() ) . ';'
+			'wpcloud.siteMutableFields=' . wp_json_encode( WPCloud_Site::get_mutable_fields() ) . ';' .
+			'wpcloud.apiConnected=' . wp_json_encode( WPCloud_Site::is_api_connected() ) . ';'
 		);
 	}
 }
-add_action( 'admin_init', 'wpcloud_block_admin_enqueue_scripts' );
+add_action( 'current_screen', 'wpcloud_block_admin_enqueue_scripts' );

--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -97,7 +97,9 @@ function wpcloud_block_available_wp_versions(): array {
 }
 
 /**
- * Enqueue the admin scripts.
+ * Enqueue the block admin scripts in the editor.
+ *
+ * @param WP_Screen $current_screen The current screen.
  *
  * @return void
  */
@@ -105,7 +107,7 @@ function wpcloud_block_admin_enqueue_scripts( $current_screen ): void {
 	if ( ! $current_screen instanceof WP_Screen ) {
 		return;
 	}
-	if ( $current_screen->is_block_editor() ) {
+	if ( $current_screen->is_block_editor() || 'site-editor' === $current_screen->base ) {
 		wp_register_script( 'wpcloud-blocks-site-form', '', array(), '1.0.0', true );
 		wp_enqueue_script( 'wpcloud-blocks-site-form' );
 		wp_add_inline_script(

--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -769,9 +769,12 @@ class WPCloud_CLI_Client extends WPCloud_CLI {
 	 * @param array $switches The switches.
 	 */
 	public function status( $args, $switches ) {
-		$test_message = $args[0];
+		$test_message = $args[0] ?? 'OK';
 		$result       = wpcloud_client_test_status( 200, $test_message );
-		self::log_result( $result );
+		if ( is_wp_error( $result ) ) {
+			return WP_CLI::error( $result->get_error_message() );
+		}
+		WP_CLI::success( 'OK' );
 	}
 }
 

--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -761,6 +761,18 @@ class WPCloud_CLI_Client extends WPCloud_CLI {
 		}
 		WP_CLI::success( 'Headstart installed' );
 	}
+
+	/**
+	 * Test the status.
+	 *
+	 * @param array $args The arguments.
+	 * @param array $switches The switches.
+	 */
+	public function status( $args, $switches ) {
+		$test_message = $args[0];
+		$result       = wpcloud_client_test_status( 200, $test_message );
+		self::log_result( $result );
+	}
 }
 
 /**

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -415,7 +415,7 @@ class WPCLOUD_Site {
 	 */
 	public static function is_api_connected(): bool {
 		$api_health = wpcloud_client_test_status();
-		return ! is_wp_error( $api_health->error );
+		return ! is_wp_error( $api_health );
 	}
 
 	/**

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -13,7 +13,6 @@ declare( strict_types = 1 );
  * Class WPCLOUD_Site
  */
 class WPCLOUD_Site {
-
 	const LINKABLE_DETAIL_KEYS = array(
 		'domain_name',
 		'wp_admin_url',
@@ -407,6 +406,16 @@ class WPCLOUD_Site {
 	 */
 	public static function get_linkable_detail_options(): array {
 		return array_intersect_key( self::get_detail_options(), array_flip( self::LINKABLE_DETAIL_KEYS ) );
+	}
+
+	/**
+	 * Check if the API is connected.
+	 *
+	 * @return bool True if the API is connected.
+	 */
+	public static function is_api_connected(): bool {
+		$api_health = wpcloud_client_test_status();
+		return ! is_wp_error( $api_health->error );
 	}
 
 	/**

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -46,9 +46,9 @@ function wpcloud_get_client_api_key(): mixed {
  * @param integer|null $wpcloud_site_id Optional. The WP Cloud Site ID.
  * @param string       $domain          The domain for which to get the IP addresses.
  *
- * @return object|WP_Error Domain verification record. WP_Error on error.
+ * @return stdClass|WP_Error Domain verification record. WP_Error on error.
  */
-function wpcloud_client_domain_ip_addresses( ?int $wpcloud_site_id, string $domain = '' ): mixed {
+function wpcloud_client_domain_ip_addresses( ?int $wpcloud_site_id, string $domain = '' ): stdClass|WP_Error {
 	$client_name = wpcloud_get_client_name();
 
 	return wpcloud_client_get( $wpcloud_site_id, "get-ips/{$client_name}/{$domain}" );

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -835,19 +835,19 @@ function wpcloud_client_job_status( int $job_id ): string|WP_Error {
 /**
  * Get the status of a test job.
  *
- * @param integer $code    The test code.
- * @param string  $message The test message.
+ * @param integer     $code    The test code.
+ * @param null|string $message The test message.
  *
  * @return true|WP_Error True if the test status matches the code and message. WP_Error on error.
  */
-function wpcloud_client_test_status( int $code = 200, string $message = 'ping' ): true|WP_Error {
+function wpcloud_client_test_status( int $code = 200, ?string $message = 'OK' ): true|WP_Error {
 	$result = wpcloud_client_get( null, "test-status/$code/$message" );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;
 	}
 
-	if ( $message !== $result->message ) {
+	if ( $message !== $result->message || 'OK' !== $result->message ) {
 		return new WP_Error( 'failure', 'Unexpected response', array( 'status' => 500 ) );
 	}
 

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -828,10 +828,31 @@ function wpcloud_client_site_persist_data_delete( int $wpcloud_site_id, string $
  *
  * @return string|WP_Error "success", "failure", "queued". WP Error on error.
  */
-function wpcloud_client_job_status( int $job_id ) {
+function wpcloud_client_job_status( int $job_id ): string|WP_Error {
 	return wpcloud_client_get( null, "job-completion/{$job_id}" );
 }
 
+/**
+ * Get the status of a test job.
+ *
+ * @param integer $code    The test code.
+ * @param string  $message The test message.
+ *
+ * @return true|WP_Error True if the test status matches the code and message. WP_Error on error.
+ */
+function wpcloud_client_test_status( int $code = 200, string $message = 'ping' ): true|WP_Error {
+	$result = wpcloud_client_get( null, "test-status/$code/$message" );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( $message !== $result->message ) {
+		return new WP_Error( 'failure', 'Unexpected response', array( 'status' => 500 ) );
+	}
+
+	return true;
+}
 /**
  * Make a GET request the WP Cloud API.
  *

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -6,15 +6,19 @@
 	"license": "GPL-3.0-or-later",
 	"main": "build/index.js",
 	"scripts": {
-		"build": "wp-scripts build --webpack-src-dir=blocks/src/ --output-path=blocks/build/ --webpack-copy-php",
+		"build": "npm run build:blocks && npm run build:frontend && npm run build:admin",
 		"format": "wp-scripts format",
 		"lint:css": "wp-scripts lint-style ./blocks/src/**/*.css",
 		"lint:js": "wp-scripts lint-js ./blocks/src/**/*.js",
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",
-		"start": "wp-scripts start --webpack-src-dir=blocks/src/ --output-path=blocks/build/ --webpack-copy-php",
-		"build:frontend": "wp-scripts build --webpack-src-dir=assets/js/src --output-path=assets/js/build",
-		"start:frontend": "wp-scripts start --webpack-src-dir=assets/js/src --output-path=assets/js/build/index.js"
+		"start": "npm run start:blocks & npm run start:frontend & npm run start:admin",
+		"build:blocks" : "wp-scripts build --webpack-src-dir=blocks/src/ --output-path=blocks/build/ --webpack-copy-php",
+		"start:blocks" : "wp-scripts start --webpack-src-dir=blocks/src/ --output-path=blocks/build/ --webpack-copy-php",
+		"build:frontend": "wp-scripts build --webpack-src-dir=assets/js/src/ --output-path=assets/js/build/",
+		"start:frontend": "wp-scripts start --webpack-src-dir=assets/js/src/ --output-path=assets/js/build/",
+		"build:admin": "wp-scripts build --webpack-src-dir=admin/assets/js/src/ --output-path=admin/assets/js/build/",
+		"start:admin": "wp-scripts start --webpack-src-dir=admin/assets/js/src/ --output-path=admin/assets/js/build/"
 	},
 	"engines": {
 		"node": ">=20.10.0",


### PR DESCRIPTION
This adds the status check endpoint to the client and shows notices when the site can not connect to the API.

On the settings page, all but the api key and client inputs are disabled if the site cannot connect. There is also some info on what could be wrong in the notice:
- Missing key or client name
- Requests rejected -> suggests making sure the IP address has been configured correctly
- Not running on WP Cloud

There are also notices on the block and site editors. Some site detail blocks might not work as expected in the editor if the site can not connect to the API. It's not ideal but since the site can't work without a valid API connection this is a reasonable workaround.