### PR TITLE
Plugin: Add option to store the API key as an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 
 /vendor/
 /build/
+docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ We welcome contributions from the community. If you would like to contribute, pl
 
 [Code of Conduct](https://github.com/Automattic/wpcloud-station/blob/trunk/CODE-OF-CONDUCT.md)
 
+### Local Setup
+
+#### Docker
+- Copy the `docker-compose.yml-example` file to `docker-compose.yaml`
+- Update the environment variable `WP_CLOUD_API_KEY` to your WP Cloud API key.
+- Run `docker compose up`
+
+#### wp-env
+- run `wp-env start`
+- Note: you will need to add your api key to the WP Cloud settings page
+
 ## Frequently Asked Questions
 
 * Can I use WP Cloud Station plugin on any site?

--- a/docker-compose.yml-example
+++ b/docker-compose.yml-example
@@ -25,7 +25,7 @@ services:
       MYSQL_ROOT_PASSWORD: somewordpress
 
   wordpress:
-    image: wordpress:php8.2
+    image: wordpress:php8.1
     volumes:
       - wp_data:/var/www/html
       - ./plugin:/var/www/html/wp-content/plugins/wpcloud-station
@@ -41,6 +41,7 @@ services:
       # Enable application passwords for REST API
       WORDPRESS_CONFIG_EXTRA: |
         define( 'WP_ENVIRONMENT_TYPE', 'local' );
+      WP_CLOUD_API_KEY: your_api_key
 
 volumes:
   db_data:

--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -92,18 +92,21 @@ function wpcloud_settings_init(): void {
 		)
 	);
 
-	add_settings_field(
-		'wpcloud_field_api_key',
-		__( 'API Key', 'wpcloud' ),
-		'wpcloud_field_input_cb',
-		'wpcloud',
-		'wpcloud_section_settings',
-		array(
-			'label_for'           => 'wpcloud_api_key',
-			'class'               => 'wpcloud_row',
-			'wpcloud_custom_data' => 'custom',
-		)
-	);
+	// Only show the API key field if it's not set in the environment.
+	if ( ! wpcloud_get_api_key() ) {
+		add_settings_field(
+			'wpcloud_field_api_key',
+			__( 'API Key', 'wpcloud' ),
+			'wpcloud_field_input_cb',
+			'wpcloud',
+			'wpcloud_section_settings',
+			array(
+				'label_for'           => 'wpcloud_api_key',
+				'class'               => 'wpcloud_row',
+				'wpcloud_custom_data' => 'custom',
+			)
+		);
+	}
 
 	add_settings_field(
 		'wpcloud_field_domain',

--- a/plugin/admin/options.php
+++ b/plugin/admin/options.php
@@ -100,7 +100,7 @@ if ( ! $wpcloud_api_healthy ) {
 				<?php if ( $client_ips ) : ?>
 				<tr class="wpcloud_row">
 					<th scope="row">
-						<label for="wpcloud_api_key">WP Cloud IP Address Range</label>
+						<label for="wpcloud_address_range">WP Cloud IP Address Range</label>
 					</th>
 					<td>
 					<?php if ( is_wp_error( $client_ips ) ) : ?>

--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -711,8 +711,11 @@ class WPCloud_CLI_Client extends WPCloud_CLI {
 
 		$options = get_option( 'wpcloud_settings' );
 
-		if ( 'api_key' === $key && isset( $options['wpcloud_api_key'] ) ) {
-			WP_CLI::confirm( 'Are you sure you want to change the API key?' );
+		// Only allow changing the API key if it's not set in the environment.
+		if ( ! wpcloud_get_api_key() ) {
+			if ( 'api_key' === $key && isset( $options['wpcloud_api_key'] ) ) {
+				WP_CLI::confirm( 'Are you sure you want to change the API key?' );
+			}
 		}
 
 		if ( 'client' === $key && isset( $options['wpcloud_client'] ) ) {

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -26,18 +26,12 @@ function wpcloud_get_client_name(): mixed {
 }
 
 /**
- * Get WP Cloud API Key from settings.
+ * Get WP Cloud API Key from settings or ENV.
  *
  * @return string|null Client API Key on success. WP_Error on error.
  */
 function wpcloud_get_client_api_key(): mixed {
-	$wpcloud_settings = get_option( 'wpcloud_settings' );
-
-	if ( ! $wpcloud_settings ) {
-		return null;
-	}
-
-	return $wpcloud_settings['wpcloud_api_key'] ?? null;
+	return wpcloud_get_api_key();
 }
 
 /**

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -37,6 +37,28 @@ if ( ! is_admin() ) {
 }
 
 /**
+ * Get the api key.
+ */
+function wpcloud_get_api_key(): string {
+
+	// Try to find the key in the ENV or config.
+	$api_key = getenv( 'WP_CLOUD_API_KEY' );
+	if ( defined( 'WP_CLOUD_API_KEY' ) ) {
+		$api_key = WP_CLOUD_API_KEY;
+	}
+
+	$api_key = apply_filters( 'wpcloud_api_key', $api_key );
+
+	if ( ! empty( $api_key ) ) {
+		return $api_key;
+	}
+
+	// Else check the local options.
+	$options = get_option( 'wpcloud_options' ) ?? array();
+	return $options['wpcloud_api_key'] ?? null;
+}
+
+/**
  * Set up the plugin's capabilities.
  */
 function wpcloud_add_capabilities(): void {

--- a/plugin/wpcloud-station.php
+++ b/plugin/wpcloud-station.php
@@ -12,25 +12,6 @@
  * @package        wpcloud-station
  */
 
-// @TODO: change this to wpcloudstation.dev once we have that domain set up.
-define( 'WPCLOUD_DEMO_DOMAIN', 'jhnstn.dev' );
-
-/**
- *  Actions
- */
-define( 'WPCLOUD_ACTION_UPDATE_SITE', 'wpcloud_update_site' );
-
-define( 'WPCLOUD_CLIENT_RESPONSE_ERROR', 'wpcloud_client_response_error' );
-define( 'WPCLOUD_CLIENT_RESPONSE_SUCCESS', 'wpcloud_client_response_success' );
-
-
-/**
- * Filters
- */
-define( 'WPCLOUD_SHOULD_CREATE_SITE', 'wpcloud_should_create_site' );
-define( 'WPCLOUD_INITIAL_SITE_STATUS', 'wpcloud_initial_site_status' );
-
-
 /**
  * Capabilities
  */


### PR DESCRIPTION
This adds the ability to store the api key as an environment variable to prevent access to the key in wp-admin.

There is also a new filter,`wpcloud_api_key`, to allow clients to store the key in some other manner.

The option to set the key in wp-admin still exists to make it easier to spin up demos.

This also updates the docker setup to use the new ENV option.


