### PR TITLE
CLI: add site import flow

### DIFF
--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -183,8 +183,8 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 	/**
 	 * List all remote sites.
 	 *
-	 * @param int $limit The limit.
-	 * @param int $after The after.
+	 * @param int  $limit The limit.
+	 * @param int  $after The after.
 	 * @param bool $remote_only Whether to list only remote sites.
 	 */
 	private static function list_remote( $limit, $after, $remote_only = false ): int {
@@ -263,9 +263,90 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 	 */
 	public function get( array $args ): void {
 		$this->set_site_id( $args );
-		$result = wpcloud_client_site_details( $this->site_id, true );
+		$result     = wpcloud_client_site_details( $this->site_id, true );
+		$local_site = WPCLOUD_Site::get_by_id( $this->site_id );
+
+		self::log( '%GLocal site:' );
+		self::log_result( $local_site );
+
+		self::log( '%GSite details:' );
 		self::log_result( $result );
 	}
+
+	/**
+	 * Import a site.
+	 *
+	 * @param array $args The arguments.
+	 */
+	public function import( array $args, array $switches ): void {
+
+		$owner_slug = $args[0] ?? '';
+		$owner      = get_user_by( 'slug', $owner_slug );
+		if ( ! $owner ) {
+			WP_CLI::error( "Owner not found: slug=`$owner_slug`" );
+			return;
+		}
+
+		if ( isset( $switches['all'] ) ) {
+			$sites = wpcloud_client_site_list();
+			if ( is_wp_error( $sites ) ) {
+				WP_CLI::error( $sites->get_error_message() );
+				return;
+			}
+			// Skip sites that already exist locally.
+			$sites = array_filter(
+				$sites,
+				function ( $site ) {
+					return ! WPCLOUD_Site::get_by_id( $site->atomic_site_id );
+				}
+			);
+
+			$total = count( $sites );
+
+			self::log(
+				sprintf(
+					_n( 'There is %s site to import', 'There are %s sites to import', $total, 'wpcloud_station'), // phpcs:ignore
+					$total
+				)
+			);
+			WP_CLI::confirm( 'Are you sure you want to import?' );
+			$progress = \WP_CLI\Utils\make_progress_bar( 'Importing', $total );
+			foreach ( $sites as $site ) {
+				$this->import_site( $site->atomic_site_id, $owner );
+				$progress->tick();
+			}
+			$progress->finish();
+			return;
+		}
+
+		$site_id = $args[1] ?? 0;
+		if ( ! $site_id ) {
+			WP_CLI::error( 'Please provide a wpcloud site id.' );
+			return;
+		}
+		$this->import_site( $site_id, $owner );
+		WP_CLI::success( 'Site imported' );
+	}
+
+	/**
+	 * Import a site.
+	 *
+	 * @param int     $site_id The site ID.
+	 * @param WP_User $owner   The owner.
+	 */
+	private function import_site( int $site_id, WP_User $owner ): bool {
+		$result = WPCLOUD_Site::import( $site_id, $owner );
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::warning( $result->get_error_message() );
+			return false;
+		}
+		if ( ! $result ) {
+			WP_CLI::warning( "Site $site_id already exists locally" );
+			return false;
+		}
+		return true;
+	}
+
 
 	/**
 	 * Update a site.

--- a/plugin/includes/class-wpcloud-cli.php
+++ b/plugin/includes/class-wpcloud-cli.php
@@ -130,82 +130,130 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 
 	/**
 	 * List all sites.
+	 * ## OPTIONS
+	 *
+	 * [--source=<all|remote|local|remote-only>]
+	 * : list sites from all contexts, remote , remote only, or local.
+	 * remote-only will list sites that are only on the remote server.
+	 * default: local
+	 *
+	 * [--limit=<limit>]
+	 * : Limit the number of remote sites to list.
+	 *
+	 * [--after=<after>]
+	 * : List remote sites after a specific site id.
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *  wp cloud site list --context=all
 	 *
 	 * @param array $args     The arguments.
 	 * @param array $switches The switches.
 	 */
 	public function list( $args, $switches = array() ) {
+		$limit   = $switches['limit'] ?? 0;
+		$after   = $switches['after'] ?? '';
+		$context = $switches['source'] ?? '';
 
-		$show_remote = $switches['remote'] ?? false;
-
-		if ( $show_remote ) {
-			$sites = wpcloud_client_site_list();
-			if ( is_wp_error( $sites ) ) {
-				WP_CLI::error( $sites->get_error_message() );
-			}
-			if ( isset( $switches['col'] ) ) {
-				$column = $switches['col'];
-				if ( 'id' === $column ) {
-					$column = 'atomic_site_id';
-				}
-				$sites = array_map(
-					function ( $site ) use ( $column ) {
-						return $site->$column;
-					},
-					$sites
-				);
-				self::log_result( implode( ' ', $sites ) );
-				return;
-			}
-			$site_list = array_map(
-				function ( $site ) {
-					return array(
-						'id'         => $site->atomic_site_id,
-						'domain'     => $site->domain_name,
-						'created'    => $site->created,
-						'space_used' => WPCLOUD_Site::readable_size( $site->space_used ),
-					);
-				},
-				$sites
-			);
-
-				WP_CLI\Utils\format_items( 'table', $site_list, array( 'id', 'domain', 'created', 'space_used' ) );
-		} else {
-			$sites = get_posts(
-				array(
-					'post_type'      => 'wpcloud_site',
-					'posts_per_page' => -1,
-					'post_status'    => 'any',
-				)
-			);
-
-			if ( isset( $switches['col'] ) ) {
-				$column = $switches['col'];
-				$sites  = array_map(
-					function ( $site ) use ( $column ) {
-						return $site->$column;
-					},
-					$sites
-				);
-				self::log_result( implode( ' ', $sites ) );
-				return;
-			}
-
-			$site_list = array_map(
-				function ( $site ) {
-					return array(
-						'wpcloud id' => get_post_meta( $site->ID, 'wpcloud_site_id', true ),
-						'id'         => $site->ID,
-						'domain'     => $site->post_title,
-						'created'    => $site->post_date,
-						'status'     => $site->post_status,
-					);
-				},
-				$sites
-			);
-
-			WP_CLI\Utils\format_items( 'table', $site_list, array( 'wpcloud id', 'id', 'domain', 'created', 'status' ) );
+		switch ( $context ) {
+			case 'all':
+				self::log( '%GRemote sites' );
+				$remote_total = self::list_remote( $limit, $after );
+				self::log( '%GLocal sites' );
+				$local_total = self::list_local();
+				self::log( '%gTotal remote sites: ' . $remote_total );
+				self::log( '%gTotal local sites: ' . $local_total );
+				break;
+			case 'remote':
+				$total = self::list_remote( $limit, $after );
+				self::log( '%gTotal remote sites: ' . $total );
+				break;
+			case 'remote-only':
+				$total = self::list_remote( $limit, $after, true );
+				self::log( '%gTotal remote only sites: ' . $total );
+				break;
+			default:
+				$total = self::list_local( $switches['col'] ?? '' );
+				self::log( '%gTotal local sites: ' . $total );
+				break;
 		}
+	}
+
+	/**
+	 * List all remote sites.
+	 *
+	 * @param int $limit The limit.
+	 * @param int $after The after.
+	 * @param bool $remote_only Whether to list only remote sites.
+	 */
+	private static function list_remote( $limit, $after, $remote_only = false ): int {
+		$sites = wpcloud_client_site_list( $limit, $after );
+		if ( $remote_only ) {
+			$sites = array_filter(
+				$sites,
+				function ( $site ) {
+					return ! WPCLOUD_Site::get_by_id( $site->atomic_site_id );
+				}
+			);
+		}
+		if ( is_wp_error( $sites ) ) {
+			WP_CLI::error( $sites->get_error_message() );
+		}
+		$site_list = array_map(
+			function ( $site ) {
+				return array(
+					'id'         => $site->atomic_site_id,
+					'domain'     => $site->domain_name,
+					'created'    => $site->created,
+					'space_used' => WPCLOUD_Site::readable_size( $site->space_used ),
+				);
+			},
+			$sites
+		);
+
+		WP_CLI\Utils\format_items( 'table', $site_list, array( 'id', 'domain', 'created', 'space_used' ) );
+		return count( $sites );
+	}
+
+	/**
+	 * List all local sites.
+	 */
+	private static function list_local( $column = '' ): int {
+		$sites = get_posts(
+			array(
+				'post_type'      => 'wpcloud_site',
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+			)
+		);
+
+		if ( $column ) {
+			$sites = array_map(
+				function ( $site ) use ( $column ) {
+					return $site->$column;
+				},
+				$sites
+			);
+			self::log_result( implode( ' ', $sites ) );
+			return count( $sites );
+		}
+
+		$site_list = array_map(
+			function ( $site ) {
+				return array(
+					'wpcloud id' => get_post_meta( $site->ID, 'wpcloud_site_id', true ),
+					'id'         => $site->ID,
+					'domain'     => $site->post_title,
+					'created'    => $site->post_date,
+					'status'     => $site->post_status,
+				);
+			},
+			$sites
+		);
+
+		WP_CLI\Utils\format_items( 'table', $site_list, array( 'wpcloud id', 'id', 'domain', 'created', 'status' ) );
+		return count( $site_list );
 	}
 
 	/**

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -99,6 +99,30 @@ class WPCLOUD_Site {
 		return $post;
 	}
 
+	/**
+	 * Get site by ID.
+	 *
+	 * @param int $wpcloud_site_id The site ID.
+	 */
+	public static function get_by_id( int $wpcloud_site_id ): null|WP_Post {
+		$site = get_posts(
+			array(
+				'post_type'   => 'wpcloud_site',
+				'post_status' => 'any',
+				'meta_query'  => array(
+					array(
+						'key'   => 'wpcloud_site_id',
+						'value' => $wpcloud_site_id,
+					),
+				),
+			)
+		);
+		if ( empty( $site ) ) {
+			return null;
+		}
+		return $site[0];
+	}
+
 
 	/**
 	 * Create a new wpcloud_site custom post type.
@@ -126,7 +150,7 @@ class WPCLOUD_Site {
 				'post_title'  => $site_name,
 				'post_name'   => $site_name,
 				'post_type'   => 'wpcloud_site',
-				'post_status' => 'draft',
+				'post_status' => $options['post_status'] ?? 'draft',
 				'post_author' => $author->ID,
 			)
 		);
@@ -138,7 +162,7 @@ class WPCLOUD_Site {
 	}
 
 	/**
-	 * Get a WPCLOUD_Site by ID.
+	 * Get detail options
 	 *
 	 * @return array The detail options
 	 */
@@ -714,5 +738,73 @@ class WPCLOUD_Site {
 			return '0 B';
 		}
 		return sprintf( '%.02F', $bytes / $divisor ) * 1 . ' ' . $sizes[ $i ];
+	}
+
+	/**
+	 * Backfill sites.
+	 *
+	 * @param WP_User $owner The owner of the sites.
+	 * @param int     $limit The number of sites to backfill.
+	 * @param int     $offset The offset to start backfilling from.
+	 *
+	 * @return array|WP_Error The sites that were backfilled.
+	 */
+	public static function backfill( WP_User $owner, $limit = 10, $offset = '' ): array|WP_Error {
+		$sites    = wpcloud_client_site_list( $limit, $offset );
+		$imported = array();
+		foreach ( $sites as $site ) {
+			$existing_site = self::get_by_id( (int) $site->atomic_site_id );
+
+			if ( $existing_site ) {
+				continue;
+			}
+			$post = self::create_post(
+				array(
+					'site_name'     => $site->domain_name,
+					'site_owner_id' => $owner->ID,
+				)
+			);
+			if ( is_wp_error( $post ) ) {
+				error_log( 'Error creating site post: ' . $post->get_error_message() );
+				continue;
+			}
+
+			update_post_meta( $post->ID, 'wpcloud_site_id', $site->atomic_site_id );
+			$imported[] = $site;
+		}
+		return $imported;
+	}
+
+	/**
+	 * Import a site.
+	 *
+	 * @param int|string $wpcloud_site_id The site ID.
+	 * @param WP_User    $owner The owner of the site.
+	 */
+	public static function import( int|string $wpcloud_site_id, WP_User $owner ): bool|WP_Error {
+		// Verify that the site exists before importing.
+		$site = wpcloud_client_site_details( (int) $wpcloud_site_id, true, false );
+		if ( is_wp_error( $site ) ) {
+			return $site;
+		}
+
+		$existing_site = self::get_by_id( (int) $wpcloud_site_id );
+
+		if ( $existing_site ) {
+			return false;
+		}
+		$post = self::create_post(
+			array(
+				'site_name'     => $site->domain_name,
+				'site_owner_id' => $owner->ID,
+				'post_status'   => 'publish',
+			)
+		);
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		update_post_meta( $post->ID, 'wpcloud_site_id', $site->atomic_site_id );
+		return true;
 	}
 }

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -309,17 +309,30 @@ function wpcloud_client_site_domain_primary_set( int $wpcloud_site_id, string $d
 /**
  * Get a list of sites for the client.
  *
- * @param string[] ...$meta_keys One or more meta keys to include in response.
+ * @param integer $limit     Optional. The number of sites to return. Default: 0 (all).
+ * @param string  $after     Optional. The site ID to start after.
+ * @param string[] $meta_keys One or more meta keys to include in response.
  *                               Supported: wp_version, php_version, space_quota, db_file_size, static_file_404, suspended.
  *
  * @return array|WP_Error Site status details or error.
  */
-function wpcloud_client_site_list( array ...$meta_keys ): mixed {
+function wpcloud_client_site_list( $limit = 0, $after = '', $meta_keys = array() ): mixed {
 	$client_name = wpcloud_get_client_name();
 	$path        = "get-sites/{$client_name}/";
 
 	foreach ( $meta_keys as $meta_key ) {
 		$path .= "{$meta_key}/";
+	}
+
+	$query = array();
+	if ( $limit > 0 ) {
+		$query['limit'] = $limit;
+	}
+	if ( $after ) {
+		$query['after'] = $after;
+	}
+	if ( ! empty( $query ) ) {
+		$path .= '?' . http_build_query( $query );
 	}
 
 	return wpcloud_client_get( null, $path );


### PR DESCRIPTION
adds `wp cloud site import` command 
- requires an owner (WP User) 
- Can import a single site
- use `--all` flag to import all sites

Also update `cloud site list` to show local, remote, all, or remote-only sites.