### PR TITLE
Add template pattern to links

### DIFF
--- a/plugin/blocks/src/components/button/render.php
+++ b/plugin/blocks/src/components/button/render.php
@@ -12,7 +12,6 @@ if ( $attributes['adminOnly'] && ! current_user_can( 'manage_options' ) ) {
 	return;
 }
 
-
 $classes           = array( 'wpcloud-block-button' );
 $button_attributes = array();
 
@@ -34,6 +33,20 @@ switch ( $block_type ) {
 	case 'link':
 		$classes[] = 'wpcloud-block-button__link wp-element-button';
 		$url       = $attributes['url'] ?? '/';
+		$matches   = array();
+		if ( preg_match( '/{(.*)}/', $url, $matches ) ) {
+			$pattern = $matches[1] ?? '';
+			if ( str_starts_with( $pattern, 'site' ) && is_wpcloud_site_post() ) {
+				global $post;
+				$attribute = str_replace( 'site.', '', $pattern );
+				try {
+					$new_value = $post->$attribute;
+					$url       = str_replace( $matches[0], $new_value, $url );
+				} catch ( Exception $e ) {
+					error_log( $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				}
+			}
+		}
 		break;
 
 	case 'action':


### PR DESCRIPTION
This adds a mini template to link buttons.
For now it only supports site posts. 
The pattern is `{site.[post atrrbute]}` 

For example to create a link that includes the current site cpt:
`site/{site.name}/some-view`