### PR TITLE
[Experimental] Add metrics

### DIFF
--- a/plugin/cli/class-wpcloud-cli-metrics.php
+++ b/plugin/cli/class-wpcloud-cli-metrics.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * WP Cloud CLI
+ *
+ * @package wpcloud
+ */
+
+declare( strict_types = 1 );
+
+require_once __DIR__ . '/class-wpcloud-cli.php';
+require_once __DIR__ . '/../includes/class-wpcloud-metrics.php';
+
+/**
+ * WP Cloud CLI Site SSH User
+ */
+class WPCloud_CLI_Metrics extends WPCloud_CLI {
+
+	/**
+	 * Get status codes
+	 *
+	 * ## OPTIONS
+	 *
+	 * <site-id>
+	 * : The site id.
+	 *
+	 *
+	 * [--format=<format>]
+	 * : The output format. Defaults to 'raw'. Options are 'json'.
+	 *
+	 * [--rollup=<rollup>]
+	 * : The rollup period in seconds. Defaults to 1 minute.
+	 *
+	 * [--start=<start>]
+	 * : The start time in hours. Defaults to 1 hour ago.
+	 *
+	 * [--end=<end>]
+	 * : The end time in hours. Defaults to now.
+	 *
+	 * [--unit=<unit>]
+	 * : The unit of time. Defaults to 'hour'. Options are 'minute', 'hour', 'day'.
+	 *
+	 * @param array $args The arguments.
+	 * @param array $options The options.
+	 */
+	public function status_codes( array $args, array $options ): void {
+		$metrics = $this->get_metrics( $args, $options );
+		$data    = $metrics->status_codes();
+		$this->print_logs( $data, $options['format'] ?? 'raw' );
+	}
+
+	/**
+	 * Get logs
+	 *
+	 * ## OPTIONS
+	 *
+	 * <site-id>
+	 * : The site id.
+	 *
+	 * <type>
+	 * : The type of logs. Options are 'server' and 'error'.
+	 *
+	 * [--format=<format>]
+	 * : The output format. Defaults to 'raw'. Options are 'json'.
+	 *
+	 * [--start=<start>]
+	 * : The start time in hours. Defaults to 1 hour ago.
+	 *
+	 * [--end=<end>]
+	 * : The end time in hours. Defaults to now.
+	 *
+	 * [--unit=<unit>]
+	 * : The unit of time. Defaults to 'hour'. Options are 'minute', 'hour', 'day'.
+	 *
+	 * @param array $args The arguments.
+	 * @param array $options The options.
+	 */
+	public function logs( array $args, array $options ): void {
+		$metrics = $this->get_metrics( $args, $options );
+		$data    = $metrics->response();
+		$this->print_logs( $data, $options['format'] ?? 'raw' );
+	}
+
+	/**
+	 * Get metrics
+	 *
+	 * @param array  $data   The data.
+	 * @param string $format The format.
+	 */
+	private function print_logs( array $data, string $format ) {
+		switch ( $format ) {
+			case 'json':
+				WP_CLI::line( wp_json_encode( $data ) );
+				break;
+			default:
+				print_r( $data ); // phpcs:ignore
+		}
+	}
+
+
+	/**
+	 * Get metrics
+	 *
+	 * @param array $args The arguments.
+	 * @param array $options The options.
+	 *
+	 * @return WP_Error|WPCloud_Metrics The metrics.
+	 */
+	private function get_metrics( array $args, array $options ): WP_Error|WPCloud_Metrics {
+		$site_id = WPCloud_CLI_Site::get_site_id( $this->api(), $args[0] );
+		$type    = $args[1] ?? 'server';
+
+		$unit = $options['unit'] ?? 'hour';
+
+		$start = $options['start'] ?? null;
+		if ( $start ) {
+			$start_date = sprintf( '-%s %ss', $start, $unit );
+			$start      = strtotime( $start_date );
+		}
+
+		$end = $options['end'] ?? null;
+		if ( $end ) {
+			$end_date = sprintf( '-%s %ss', $end, $unit );
+			$end      = strtotime( $end_date );
+		}
+
+		try {
+			$metrics = new WPCloud_Metrics( site: $site_id, type: $type, start: $start, end: $end );
+		} catch ( Exception $e ) {
+				WP_CLI::error( $e );
+				die( 1 );
+		}
+		return $metrics;
+	}
+}

--- a/plugin/cli/class-wpcloud-cli-site.php
+++ b/plugin/cli/class-wpcloud-cli-site.php
@@ -433,15 +433,24 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 	 * @param array $args The arguments.
 	 */
 	protected function set_site_id( $args ) {
-		$this->site_id = $args[0] ?? 0;
+		$this->site_id = self::get_site_id( $this->api(), $args[0] ?? 0 );
+	}
+
+	/**
+	 * Get site id
+	 *
+	 * @param WPCLOUD_CLI_Api $api The wpcloud api.
+	 * @param string|int      $site_id The site ID.
+	 */
+	public static function get_site_id( WPCLOUD_CLI_Api $api, string|int $site_id = 0 ): null|int {
 
 		// Check the local sites first.
 		$site_cpt = null;
-		if ( ! is_numeric( $this->site_id ) ) {
+		if ( ! is_numeric( $site_id ) ) {
 			$query = new WP_Query(
 				array(
 					'post_type'   => 'wpcloud_site',
-					'title'       => $this->site_id,
+					'title'       => $site_id,
 					'post_status' => 'any',
 					'numberposts' => 1,
 				)
@@ -449,36 +458,40 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 
 			$site_cpt = $query->have_posts() ? $query->posts[0] : null;
 		} else {
-			$site_cpt = get_post( $this->site_id );
+			$site_cpt = get_post( $site_id );
 		}
 
 		if ( $site_cpt && ! is_wp_error( $site_cpt ) ) {
-			$this->site_id = (int) get_post_meta( $site_cpt->ID, 'wpcloud_site_id', true );
+			$site_id = (int) get_post_meta( $site_cpt->ID, 'wpcloud_site_id', true );
 
-			if ( ! $this->site_id ) {
+			if ( ! $site_id ) {
 				WP_CLI::error( sprintf( 'Local site %s is missing a wp cloud site id', $site_cpt->post_title ) );
+				return null;
 			}
-			return;
+			return $site_id;
 		}
-		if ( ! is_numeric( $this->site_id ) ) {
-			$sites = $this->api()->site_list()->result;
+
+		if ( ! is_numeric( $site_id ) ) {
+			$sites = $api->site_list()->result;
 			$site  = array_filter(
 				$sites,
-				function ( $site ) {
-					return $site->domain_name === $this->site_id;
+				function ( $site ) use ( $site_id ) {
+					return $site_id === $site->domain_name;
 				}
 			);
 
 			if ( empty( $site ) ) {
 				WP_CLI::error( 'Site not found.' );
 			}
-			$site          = reset( $site );
-			$this->site_id = (int) $site->atomic_site_id;
+			$site    = reset( $site );
+			$site_id = (int) $site->atomic_site_id;
 		}
 
-		if ( ! $this->site_id ) {
+		if ( ! $site_id ) {
 			WP_CLI::error( 'Please provide a site id.' );
+			return null;
 		}
+		return $site_id;
 	}
 
 	/**
@@ -491,7 +504,7 @@ class WPCloud_CLI_Site extends WPCloud_CLI {
 		$query = array(
 			'post_type'   => 'wpcloud_site',
 			'post_status' => 'any',
-			'meta_query'  => array(
+			'meta_query'  => array( // phpcs:ignore
 				array(
 					'key'   => 'wpcloud_site_id',
 					'value' => $this->site_id,

--- a/plugin/cli/class-wpcloud-cli.php
+++ b/plugin/cli/class-wpcloud-cli.php
@@ -58,7 +58,7 @@ class WPCloud_CLI {
 				return self::log_result( $value, $padding );
 			}
 
-			if ( str_contains( $key, 'wpcom' ) || is_object( $value ) ) {
+			if ( str_contains( (string) $key, 'wpcom' ) || is_object( $value ) ) {
 				continue;
 			}
 

--- a/plugin/cli/init.php
+++ b/plugin/cli/init.php
@@ -12,6 +12,8 @@ require_once __DIR__ . '/class-wpcloud-cli-client-meta.php';
 
 require_once __DIR__ . '/class-wpcloud-cli-job.php';
 
+require_once __DIR__ . '/class-wpcloud-cli-metrics.php';
+
 require_once __DIR__ . '/class-wpcloud-cli-site.php';
 require_once __DIR__ . '/class-wpcloud-cli-site-domain.php';
 require_once __DIR__ . '/class-wpcloud-cli-site-ssh-user.php';
@@ -23,6 +25,7 @@ add_action(
 		WP_CLI::add_command( 'cloud client', 'WPCloud_CLI_Client' );
 		WP_CLI::add_command( 'cloud client meta', 'WPCloud_CLI_Client_Meta' );
 		WP_CLI::add_command( 'cloud job', 'WPCloud_CLI_Job' );
+		WP_CLI::add_command( 'cloud metrics', 'WPCloud_CLI_Metrics' );
 		WP_CLI::add_command( 'cloud site', 'WPCloud_CLI_Site' );
 		WP_CLI::add_command( 'cloud site domain', 'WPCloud_CLI_Site_Domain' );
 		WP_CLI::add_command( 'cloud site ssh-user', 'WPCloud_CLI_Site_SSH_User' );

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * WP Cloud Metrics Controller
+ *
+ * @package wpcloud-station
+ */
+
+declare( strict_types = 1 );
+
+if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
+
+	/**
+	 * Class WPCLOUD_Metrics_Controller
+	 */
+	class WPCLOUD_Metrics_Controller extends WP_REST_Controller {
+
+		/**
+		 * The namespace.
+		 *
+		 * @var string
+		 */
+		protected $namespace = 'wpcloud-station/v1';
+
+		/**
+		 * Rest base for the current object.
+		 *
+		 * @var string
+		 */
+		protected $rest_base = '/metrics';
+
+		/**
+		 * Register the routes for the objects of the controller.
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				$this->rest_base . '/site/(?P<id>[\d]+)',
+				array(
+					'args' => array(
+						'id' => array(
+							'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
+							'type'        => 'integer',
+						),
+					),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_site_metric' ),
+					'permission_callback' => array( $this, 'user_access_check' ),
+				)
+			);
+		}
+
+		public function get_site_metric( WP_REST_Request $request ): WP_REST_Response {
+			$params = $request->get_params();
+			$site_id = $params['id'];
+
+			$site = WPCLOUD_Site::get_site( $site_id );
+
+			if ( ! $site ) {
+				return new WP_Error( 'rest_site_not_found', esc_html__( 'Site not found', 'wpcloud' ), array( 'status' => 404 ) );
+			}
+
+			$metrics = new WPCLOUD_Metrics( site: $site_id, type: 'server' );
+
+			$metrics->filter( $params );
+
+			return new WP_REST_Response( $metrics, 200 );
+		}
+
+
+		/**
+		 * Check permissions for the current request.
+		 *
+		 * @return bool|WP_Error True if the requester has manage site capabilities. False if logged in but with out manage site capabilities, WP_Error if not logged in.
+		 */
+		protected function user_access_check(): bool|WP_Error {
+			if ( is_user_logged_in() && current_user_can( WPCLOUD_CAN_MANAGE_SITES ) ) {
+				return true;
+			}
+			return new WP_Error( 'rest_forbidden', esc_html__( 'Unauthorized request', 'wpcloud' ), rest_authorization_required_code() );
+		}
+	}
+}

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * WP Cloud Metrics
+ *
+ * @package wpcloud
+ */
+
+declare( strict_types = 1 );
+
+require_once __DIR__ . '/wpcloud-client.php';
+
+/**
+ * WP Cloud Metrics
+ */
+class WPCloud_Metrics {
+
+	/**
+	 * The site.
+	 *
+	 * @var int
+	 */
+	private int $site;
+
+	/**
+	 * The start.
+	 *
+	 * @var int|null
+	 */
+	private ?int $start;
+
+	/**
+	 * The end.
+	 *
+	 * @var int|null
+	 */
+	private ?int $end;
+
+	/**
+	 * The options.
+	 *
+	 * @var array
+	 */
+	private $options;
+
+	/**
+	 * The raw data.
+	 *
+	 * @var array
+	 */
+	private $log_data;
+
+	/**
+	 * The result.
+	 *
+	 * @var mixed
+	 */
+	private $result;
+
+	/**
+	 * HTTP status codes.
+	 *
+	 * @var array
+	 */
+	const HTTP_STATUS_CODES = array(
+		100 => 'Continue',
+		101 => 'Switching Protocols',
+		102 => 'Processing',
+		103 => 'Checkpoint',
+		200 => 'OK',
+		201 => 'Created',
+		202 => 'Accepted',
+		203 => 'Non-Authoritative Information',
+		204 => 'No Content',
+		205 => 'Reset Content',
+		206 => 'Partial Content',
+		207 => 'Multi-Status',
+		300 => 'Multiple Choices',
+		301 => 'Moved Permanently',
+		302 => 'Found',
+		303 => 'See Other',
+		304 => 'Not Modified',
+		305 => 'Use Proxy',
+		306 => 'Switch Proxy',
+		307 => 'Temporary Redirect',
+		400 => 'Bad Request',
+		401 => 'Unauthorized',
+		402 => 'Payment Required',
+		403 => 'Forbidden',
+		404 => 'Not Found',
+		405 => 'Method Not Allowed',
+		406 => 'Not Acceptable',
+		407 => 'Proxy Authentication Required',
+		408 => 'Request Timeout',
+		409 => 'Conflict',
+		410 => 'Gone',
+		411 => 'Length Required',
+		412 => 'Precondition Failed',
+		413 => 'Request Entity Too Large',
+		414 => 'Request-URI Too Long',
+		415 => 'Unsupported Media Type',
+		416 => 'Requested Range Not Satisfiable',
+		417 => 'Expectation Failed',
+		418 => 'I\'m a teapot',
+		422 => 'Unprocessable Entity',
+		423 => 'Locked',
+		424 => 'Failed Dependency',
+		425 => 'Unordered Collection',
+		426 => 'Upgrade Required',
+		449 => 'Retry With',
+		450 => 'Blocked by Windows Parental Controls',
+		500 => 'Internal Server Error',
+		501 => 'Not Implemented',
+		502 => 'Bad Gateway',
+		503 => 'Service Unavailable',
+		504 => 'Gateway Timeout',
+		505 => 'HTTP Version Not Supported',
+		506 => 'Variant Also Negotiates',
+		507 => 'Insufficient Storage',
+		509 => 'Bandwidth Limit Exceeded',
+		510 => 'Not Extended',
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int      $site    The site.
+	 * @param string   $type    The type.
+	 * @param int|null $start   The start.
+	 * @param int|null $end     The end.
+	 * @param array    $options The options.
+	 *
+	 * @throws Exception If the type is invalid.
+	 */
+	public function __construct( int $site, string $type, ?int $start = null, ?int $end = null, $options = array() ) {
+		$this->site    = $site;
+		$this->start   = $start ?? strtotime( '-24 hours' );
+		$this->end     = $end ?? time();
+		$this->options = $options;
+
+		switch ( $type ) {
+			case 'server':
+				$this->result = wpcloud_client_site_logs( $this->site, $this->start, $this->end, $options );
+				break;
+			case 'error':
+				$this->result = wpcloud_client_site_error_logs( $this->site, $this->start, $this->end, $options );
+				break;
+			default:
+				throw new Exception( 'Invalid type' );
+		}
+
+		if ( is_wp_error( $this->result ) ) {
+			throw new Exception( $this->result->get_error_message() ); // phpcs:ignore
+		} else {
+			$this->log_data = $this->result->logs;
+		}
+	}
+
+	/**
+	 * Get raw log data.
+	 *
+	 * @return WP_Error|array The raw log data.
+	 */
+	public function logs(): WP_Error|array {
+		return $this->log_data;
+	}
+
+	/**
+	 * Get the response.
+	 *
+	 * @return WP_Error|array The response.
+	 */
+	public function response(): WP_Error|array {
+		return (array) $this->result;
+	}
+
+	/**
+	 * Get the status codes.
+	 *
+	 * @param int   $rollup_interval_sec The rollup interval in seconds.
+	 * @param array $codes               The status codes.
+	 *
+	 * @return mixed The status codes.
+	 */
+	public function status_codes( int $rollup_interval_sec = 60, $codes = array() ): mixed {
+		if ( is_wp_error( $this->log_data ) ) {
+			return $this->log_data;
+		}
+		if ( empty( $codes ) ) {
+			$codes = array_keys( self::HTTP_STATUS_CODES );
+		}
+		$options           = $this->options;
+		$options['filter'] = array( 'status' => $codes );
+
+		return $this->rollup( 'status', $rollup_interval_sec );
+	}
+
+	/**
+	 * Get the status codes rollup.
+	 *
+	 * @param string $key                 The key.
+	 * @param int    $rollup_interval_sec The rollup interval in seconds.
+	 *
+	 * @return mixed The status codes rollup.
+	 */
+	protected function rollup( $key, $rollup_interval_sec ): WP_Error|array {
+		$rollup = array();
+		foreach ( $this->log_data as $row ) {
+			$timestamp            = $row->timestamp;
+			$timestamp            = $timestamp - ( $timestamp % $rollup_interval_sec );
+			$rollup[ $timestamp ] = $rollup[ $timestamp ] ?? array();
+			if ( ! property_exists( $row, $key ) ) {
+				return new WP_Error( 'invalid_rollup_key', "Invalid rollup key:	$key" );
+			}
+			$term = $row->$key;
+
+			$rollup[ $timestamp ][ $term ] = $rollup[ $timestamp ][ $term ] ?? 0;
+			++$rollup[ $timestamp ][ $term ];
+		}
+		return $rollup;
+	}
+}


### PR DESCRIPTION
This adds a metric class to fetch logs and roll up the data for analyzing metrics.
For now, it only supports rolling up request status metrics. 


Also includes a `cloud metric` cli command to fetch metrics

NOTE: This is still experimental. The requests do not consider paging in the event that the log data is too large for a single request.