### PR TITLE
Update default php - set to 8.2

### DIFF
--- a/plugin/blocks/init.php
+++ b/plugin/blocks/init.php
@@ -65,7 +65,26 @@ function wpcloud_block_available_php_options(): array {
 		error_log( 'WP Cloud: ' . $php_versions->get_error_message() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		return array( '' => __( 'No Preference' ) );
 	}
-	return (array) $php_versions;
+
+	$default_version = defined( 'DEFAULT_PHP_VERSION' ) ? DEFAULT_PHP_VERSION : '';
+
+	$options = array();
+	foreach ( (array) $php_versions as $version ) {
+		$option = array(
+			'label'   => $version,
+			'value'   => $version,
+			'default' => $default_version === $version,
+		);
+
+		if ( $default_version === $version ) {
+			$option['default'] = true;
+			$option['label']  .= __( ' (default)' );
+		}
+
+		$options[] = $option;
+	}
+
+	return $options;
 }
 
 /**

--- a/plugin/blocks/src/components/form-input/fields/select.js
+++ b/plugin/blocks/src/components/form-input/fields/select.js
@@ -26,6 +26,7 @@ export default function SelectField( {
 		options = optionData;
 	}
 
+	const selected = options.find( ( option ) => option.value === value || option.default );
 	return (
 		<div className="wpcloud-form-input--select--wrapper">
 			<select
@@ -35,6 +36,7 @@ export default function SelectField( {
 				style={ inputStyle }
 				name={ name }
 				required={ required }
+				value={ selected?.value }
 			>
 				{ options.map( ( option, index ) => ( <option key={ index } value={ option.value }>{ option.label }</option> ) ) }
 			</select>

--- a/plugin/blocks/src/site-create/edit.js
+++ b/plugin/blocks/src/site-create/edit.js
@@ -166,7 +166,7 @@ export default function Edit() {
 							type: 'select',
 							label: __( 'PHP Version' ),
 							name: 'php_version',
-							options: formatOptions( phpVersionOptions ),
+							options: phpVersionOptions,
 							metadata: { name: 'PHP Version' },
 						},
 					],

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -481,7 +481,14 @@ class WPCLOUD_Site {
 	public static function get_detail( int|WP_Post $post, string $key, ): mixed {
 		$wpcloud_site_id = wpcloud_get_site_id( $post );
 		if ( empty( $wpcloud_site_id ) ) {
-			return null;
+
+			// Check for default values.
+			switch ( $key ) {
+				case 'php_version':
+					return DEFAULT_PHP_VERSION;
+				default:
+					return null;
+			}
 		}
 
 		$result = '';

--- a/plugin/wpcloud-station.php
+++ b/plugin/wpcloud-station.php
@@ -28,6 +28,8 @@ define( 'WPCLOUD_CATEGORY_CORE', 'wpcloud_core_pages' );
 
 define( 'WP_STATION_CLIENT_ID', '61' );
 
+define( 'DEFAULT_PHP_VERSION', '8.2' );
+
 
 // Initialize the plugin.
 require_once plugin_dir_path( __FILE__ ) . 'init.php';


### PR DESCRIPTION
This update the editor and frontend to select a default PHP version
Note: This only shows a "default" label in the editor.