### PR TITLE
Block: add form message

### DIFF
--- a/plugin/assets/js/src/index.js
+++ b/plugin/assets/js/src/index.js
@@ -2,3 +2,27 @@ import { createHooks } from '@wordpress/hooks';
 
 window.wpcloud = window.wpcloud || {};
 wpcloud.hooks = wpcloud.hooks || createHooks();
+
+wpcloud.hooks.addAction('all', 'wpcloud', (hookName, ...args) => {
+	console.log('Hook:', hookName, 'Args:', args);
+});
+
+wpcloud.scrollTo = (element) => {
+	element.scrollIntoView({ behavior: "smooth", block: "center" });
+
+	const animate = (name) => (...targets) => {
+		const toAnimate = targets.map((selector) => element.querySelector(selector));
+
+		setTimeout(() => {
+			toAnimate.forEach((el) => {
+				el.classList.add(name);
+
+				el.addEventListener("animationend", () => {
+					el.classList.remove(name);
+				}, { once: true });
+			})
+		}, 500);
+	}
+
+	return { andPulse: animate("pulse"), andHighlight: animate("highlight") };
+	}

--- a/plugin/blocks/src/components/button/view.js
+++ b/plugin/blocks/src/components/button/view.js
@@ -4,10 +4,8 @@
 	const blockedActions = [
 		'wpcloud_form_submit',
 		'wpcloud_expanding_section_toggle_end',
-		'wpcloud_expanding_section_toggle',
 		'wpcloud_alias_added',
 		'wpcloud_site_ssh_user_added',
-		'wpcloud_expanding_section_toggle',
 	];
 	// Bind clicks to any action buttons
 	const buttons = document.querySelectorAll('.wp-block-wpcloud-button');

--- a/plugin/blocks/src/components/dropdown/block.json
+++ b/plugin/blocks/src/components/dropdown/block.json
@@ -70,6 +70,10 @@
 		"secondary": {
 			"type": "boolean",
 			"default": false
+		},
+		"onRight": {
+			"type": "boolean",
+			"default": false
 		}
 	}
 }

--- a/plugin/blocks/src/components/dropdown/edit.js
+++ b/plugin/blocks/src/components/dropdown/edit.js
@@ -40,6 +40,7 @@ export default function Edit({ clientId, attributes, setAttributes }) {
 		accordion,
 		hideChevron,
 		summary,
+		onRight,
 
 		level,
 		levelOptions,
@@ -141,6 +142,11 @@ export default function Edit({ clientId, attributes, setAttributes }) {
 						checked={hideChevron}
 						onChange={update('hideChevron')}
 					/>
+					<ToggleControl
+						label={__('Open On Right')}
+						checked={onRight}
+						onChange={update('onRight')}
+					/>
 					<ButtonControls {...{ attributes, setAttributes }} />
 					<ToggleControl
 						label={__('Use Icon')}
@@ -158,6 +164,7 @@ export default function Edit({ clientId, attributes, setAttributes }) {
 				className={classnames(className, {
 					'dropdown': !accordion,
 					'hide-chevron': hideChevron,
+					'open-right': onRight
 				})}
 			>
 				<summary

--- a/plugin/blocks/src/components/dropdown/save.js
+++ b/plugin/blocks/src/components/dropdown/save.js
@@ -11,7 +11,21 @@ import * as icons from '@wordpress/icons';
 const Icon = icons.Icon;
 
 export default function save({ attributes }) {
-	const { accordion, hideChevron, level, summary, useIcon, icon, iconSize, button, secondary, outline, contrast } = attributes;
+	const {
+		accordion,
+		hideChevron,
+		level,
+		summary,
+		useIcon,
+		icon,
+		iconSize,
+		button,
+		secondary,
+		outline,
+		contrast,
+		onRight
+	} = attributes;
+
 	const blockProps = useBlockProps.save();
 
 	const summaryContent = useIcon
@@ -31,6 +45,7 @@ export default function save({ attributes }) {
 				{
 					'dropdown' : !accordion,
 					'hide-chevron': hideChevron,
+					'open-right': onRight
 				}
 		)}>
 			<summary
@@ -39,9 +54,14 @@ export default function save({ attributes }) {
 			>
 				{summaryContent}
 			</summary>
-			<ul>
-				<InnerBlocks.Content />
-			</ul>
+			{ accordion
+				? ( <InnerBlocks.Content /> )
+				: (
+					<ul>
+						<InnerBlocks.Content />
+					</ul>
+				)
+			}
 		</details>
 	)
 }

--- a/plugin/blocks/src/components/form-input/block.json
+++ b/plugin/blocks/src/components/form-input/block.json
@@ -93,6 +93,14 @@
 	"supports": {
 		"anchor": true,
 		"reusable": false,
+		"color": {
+			"gradients": true,
+			"background": true,
+			"text": true,
+			"link": true,
+			"border": true,
+			"custom": true
+		},
 		"spacing": {
 			"margin": [ "top", "bottom" ]
 		},

--- a/plugin/blocks/src/components/form-message/block.json
+++ b/plugin/blocks/src/components/form-message/block.json
@@ -24,6 +24,10 @@
 		"dismiss":{
 			"type": "boolean",
 			"default": true
+		},
+		"message": {
+			"type": "string",
+			"default": ""
 		}
 	},
 

--- a/plugin/blocks/src/components/form-message/block.json
+++ b/plugin/blocks/src/components/form-message/block.json
@@ -25,12 +25,19 @@
 			"type": "boolean",
 			"default": true
 		},
+		"icon" :{
+			"type": "string",
+			"default": "close"
+		},
+		"iconSize": {
+			"type": "number",
+			"default": 20
+		},
 		"message": {
 			"type": "string",
 			"default": ""
 		}
 	},
-
 	"supports": {
 		"anchor": true,
 		"reusable": false,

--- a/plugin/blocks/src/components/form-message/block.json
+++ b/plugin/blocks/src/components/form-message/block.json
@@ -1,0 +1,52 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "wpcloud/form-message",
+	"version": "0.1.0",
+	"title": "Form Message",
+	"category": "wpcloud",
+	"icon": "forms",
+	"description": "WP Cloud Form Message block",
+	"example": {},
+	"textdomain": "wpcloud",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"viewScript": "file:./view.js",
+	"attributes": {
+		"success": {
+			"type": "boolean",
+			"default": true
+		},
+		"action": {
+			"type": "string",
+			"default": ""
+		},
+		"dismiss":{
+			"type": "boolean",
+			"default": true
+		}
+	},
+
+	"supports": {
+		"anchor": true,
+		"reusable": false,
+		"color": {
+			"gradients": true,
+			"background": true,
+			"text": true,
+			"link": true,
+			"border": true,
+			"custom": true
+		},
+		"spacing": {
+			"margin": [ "top", "bottom" ]
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"radius": true
+			}
+		}
+	}
+}

--- a/plugin/blocks/src/components/form-message/editor.scss
+++ b/plugin/blocks/src/components/form-message/editor.scss
@@ -4,6 +4,14 @@
 	padding: 10px;
 	margin: 10px 0;
 
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	svg {
+		fill: currentColor;
+	}
+
 	&.wpcloud-form-message--success {
 		border-color: green;
 	}

--- a/plugin/blocks/src/components/form-message/editor.scss
+++ b/plugin/blocks/src/components/form-message/editor.scss
@@ -1,0 +1,13 @@
+.wpcloud-form-message {
+	border: 1px dashed #e5e5e5;
+	border-radius: 2px;
+	padding: 10px;
+	margin: 10px 0;
+
+	&.wpcloud-form-message--success {
+		border-color: green;
+	}
+	&.wpcloud-form-message--error {
+		border-color: red;
+	}
+}

--- a/plugin/blocks/src/components/form-message/index.js
+++ b/plugin/blocks/src/components/form-message/index.js
@@ -29,7 +29,7 @@ import './editor.scss';
 
 registerBlockType( metadata.name, {
 	edit: ({ attributes, setAttributes }) => {
-		const { success, action }	= attributes;
+		const { success, action, message }	= attributes;
 		const template = [ ['core/paragraph'] ];
 
 		const blockProps = useBlockProps();
@@ -43,7 +43,6 @@ registerBlockType( metadata.name, {
 					<PanelBody title={__('Message Settings')}>
 						<RadioControl
 							label={ __( 'Message Type' ) }
-							help="Dropdown or Accordion. Dropdown will open over the content, Accordion will push the content down."
 							selected={ success }
 							options={ [
 								{ label: __( 'Success' ), value: true },
@@ -57,32 +56,35 @@ registerBlockType( metadata.name, {
 							label={ __( 'WP Cloud Action' ) }
 							value={ action }
 							onChange={update('action')}
-							help={ __( 'The WP Cloud form action to respond to. Use the template {response.message} in the rich text to display the form response.' ) }
+							help={ __( 'The WP Cloud form action to respond to. Use JavaScript templates to render response information. For example `${response.message}` will display the response message' ) }
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<article {...innerBlocksProps}
+				<article {...blockProps}
 					className={classnames(
 						blockProps.className,
 						'wpcloud-form-message',
 						{ 'wpcloud-form-message--success': success },
 						{ 'wpcloud-form-message--error': !success })
 					}
-			data-wpcloud-action={action}/>
+					data-wpcloud-action={action}
+				>
+					<RichText tagName="p" value={message} onChange={update('message')} />
+			</article>
 			</>
 		)
 
 	},
 	save: ({ attributes, innerBlocks }) => {
-		const { success, action } = attributes;
+		const { success, action, message } = attributes;
 		const blockProps = useBlockProps.save();
-		const innerBlocksProps = useInnerBlocksProps.save(blockProps);
+
 		const role = success ? 'status' : 'alert';
 		const ariaLive = success ? 'polite' : 'assertive';
 
-		console.log(innerBlocks);
+
 		return (
-			<article  {...innerBlocksProps}
+			<article  {...blockProps}
 				className={classnames(
 					blockProps.className,
 					'hidden',
@@ -93,7 +95,10 @@ registerBlockType( metadata.name, {
 				data-message-type={success ? 'success' : 'error'}
 				role={role}
 				aria-live={ariaLive}
-			/>
+				data-message-template={message}
+			>
+				<p />
+			</article>
 		);
 	},
 } );

--- a/plugin/blocks/src/components/form-message/index.js
+++ b/plugin/blocks/src/components/form-message/index.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import {
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	HeadingLevelDropdown,
+	BlockControls,
+	RichText,
+	InnerBlocks
+} from '@wordpress/block-editor';
+import { PanelBody, TextControl, RadioControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { updateAttribute } from '@wpcloud/controls/utils';
+import metadata from './block.json';
+import './editor.scss';
+
+
+registerBlockType( metadata.name, {
+	edit: ({ attributes, setAttributes }) => {
+		const { success, action }	= attributes;
+		const template = [ ['core/paragraph'] ];
+
+		const blockProps = useBlockProps();
+
+		const innerBlocksProps = useInnerBlocksProps(blockProps, { template, templateLock: 'insert' });
+		const update = updateAttribute(setAttributes);
+
+		return (
+			<>
+				<InspectorControls>
+					<PanelBody title={__('Message Settings')}>
+						<RadioControl
+							label={ __( 'Message Type' ) }
+							help="Dropdown or Accordion. Dropdown will open over the content, Accordion will push the content down."
+							selected={ success }
+							options={ [
+								{ label: __( 'Success' ), value: true },
+								{ label: __( 'Error' ), value: false },
+							] }
+							onChange={(option) => {
+								setAttributes({ success: option === 'true' });
+							}}
+						/>
+						<TextControl
+							label={ __( 'WP Cloud Action' ) }
+							value={ action }
+							onChange={update('action')}
+							help={ __( 'The WP Cloud form action to respond to. Use the template {response.message} in the rich text to display the form response.' ) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<article {...innerBlocksProps}
+					className={classnames(
+						blockProps.className,
+						'wpcloud-form-message',
+						{ 'wpcloud-form-message--success': success },
+						{ 'wpcloud-form-message--error': !success })
+					}
+			data-wpcloud-action={action}/>
+			</>
+		)
+
+	},
+	save: ({ attributes, innerBlocks }) => {
+		const { success, action } = attributes;
+		const blockProps = useBlockProps.save();
+		const innerBlocksProps = useInnerBlocksProps.save(blockProps);
+		const role = success ? 'status' : 'alert';
+		const ariaLive = success ? 'polite' : 'assertive';
+
+		console.log(innerBlocks);
+		return (
+			<article  {...innerBlocksProps}
+				className={classnames(
+					blockProps.className,
+					'hidden',
+					'wpcloud-form-message',
+					{ 'wpcloud-form-message--success': success },
+					{ 'wpcloud-form-message--error': !success })}
+				data-wpcloud-action={action}
+				data-message-type={success ? 'success' : 'error'}
+				role={role}
+				aria-live={ariaLive}
+			/>
+		);
+	},
+} );

--- a/plugin/blocks/src/components/form-message/index.js
+++ b/plugin/blocks/src/components/form-message/index.js
@@ -17,24 +17,24 @@ import {
 	RichText,
 	InnerBlocks
 } from '@wordpress/block-editor';
-import { PanelBody, TextControl, RadioControl } from '@wordpress/components';
+import { PanelBody, TextControl, RadioControl, ToggleControl } from '@wordpress/components';
+
+import * as icons from '@wordpress/icons';
+const Icon = icons.Icon;
 
 /**
  * Internal dependencies
  */
 import { updateAttribute } from '@wpcloud/controls/utils';
+import { IconControls } from '@wpcloud/controls';
 import metadata from './block.json';
 import './editor.scss';
 
 
 registerBlockType( metadata.name, {
 	edit: ({ attributes, setAttributes }) => {
-		const { success, action, message }	= attributes;
-		const template = [ ['core/paragraph'] ];
-
+		const { success, action, message, dismiss, icon, iconSize }	= attributes;
 		const blockProps = useBlockProps();
-
-		const innerBlocksProps = useInnerBlocksProps(blockProps, { template, templateLock: 'insert' });
 		const update = updateAttribute(setAttributes);
 
 		return (
@@ -58,6 +58,12 @@ registerBlockType( metadata.name, {
 							onChange={update('action')}
 							help={ __( 'The WP Cloud form action to respond to. Use JavaScript templates to render response information. For example `${response.message}` will display the response message' ) }
 						/>
+						<ToggleControl
+							label={__('Dismissable')}
+							checked={dismiss}
+							onChange={update('dismiss')}
+						/>
+					{       dismiss && <IconControls {...{ attributes, setAttributes }} /> }
 					</PanelBody>
 				</InspectorControls>
 				<article {...blockProps}
@@ -70,18 +76,18 @@ registerBlockType( metadata.name, {
 					data-wpcloud-action={action}
 				>
 					<RichText tagName="p" value={message} onChange={update('message')} />
+					{ dismiss && <Icon icon={ icons[icon] } size={iconSize} /> }
 			</article>
 			</>
 		)
 
 	},
-	save: ({ attributes, innerBlocks }) => {
-		const { success, action, message } = attributes;
+	save: ({ attributes }) => {
+		const { success, action, message, dismiss, icon, iconSize } = attributes;
 		const blockProps = useBlockProps.save();
 
 		const role = success ? 'status' : 'alert';
 		const ariaLive = success ? 'polite' : 'assertive';
-
 
 		return (
 			<article  {...blockProps}
@@ -98,6 +104,8 @@ registerBlockType( metadata.name, {
 				data-message-template={message}
 			>
 				<p />
+				{ dismiss && <Icon icon={ icons[icon] } size={iconSize}  class="dismiss" /> }
+
 			</article>
 		);
 	},

--- a/plugin/blocks/src/components/form-message/view.js
+++ b/plugin/blocks/src/components/form-message/view.js
@@ -1,0 +1,21 @@
+
+const formMessages = document.querySelectorAll('.wpcloud-form-message');
+
+formMessages.forEach((formMessage) => {
+	const { wpcloudAction, messageType } = formMessage.dataset;
+
+	wpcloud.hooks.addAction(
+		`wpcloud_form_response_${wpcloudAction}`,
+		'wpcloud',
+		(response) => {
+			const message = response.message;
+			const success = response.success;
+			if (messageType === 'success' && success) {
+				formMessage.classList.remove('hidden');
+			}
+			if (messageType === 'error' && !success) {
+				formMessage.classList.remove('hidden');
+			}
+		}
+	);
+});

--- a/plugin/blocks/src/components/form-message/view.js
+++ b/plugin/blocks/src/components/form-message/view.js
@@ -18,4 +18,13 @@ formMessages.forEach((formMessage) => {
 			}
 		}
 	);
+
+	// clear out any existing messages
+	wpcloud.hooks.addAction(
+		`wpcloud_form_submit_${wpcloudAction}`,
+		'wpcloud',
+		() => {
+			formMessage.classList.add('hidden');
+		}
+	);
 });

--- a/plugin/blocks/src/components/form-message/view.js
+++ b/plugin/blocks/src/components/form-message/view.js
@@ -2,13 +2,22 @@
 const formMessages = document.querySelectorAll('.wpcloud-form-message');
 
 formMessages.forEach((formMessage) => {
-	const { wpcloudAction, messageType } = formMessage.dataset;
+	const { wpcloudAction, messageType, messageTemplate } = formMessage.dataset;
 
 	wpcloud.hooks.addAction(
 		`wpcloud_form_response_${wpcloudAction}`,
 		'wpcloud',
 		(response) => {
-			const message = response.message;
+			console.log('response', response);
+			const render = new Function('response', `return \`${messageTemplate}\`;`);
+			const p = formMessage.querySelector('p');
+			try {
+				p.innerHTML = render(response);
+			} catch (error) {
+				console.error(error);
+				p.innerHTML = messageTemplate;
+			}
+
 			const success = response.success;
 			if (messageType === 'success' && success) {
 				formMessage.classList.remove('hidden');

--- a/plugin/blocks/src/components/form-message/view.js
+++ b/plugin/blocks/src/components/form-message/view.js
@@ -8,7 +8,6 @@ formMessages.forEach((formMessage) => {
 		`wpcloud_form_response_${wpcloudAction}`,
 		'wpcloud',
 		(response) => {
-			console.log('response', response);
 			const render = new Function('response', `return \`${messageTemplate}\`;`);
 			const p = formMessage.querySelector('p');
 			try {
@@ -36,4 +35,12 @@ formMessages.forEach((formMessage) => {
 			formMessage.classList.add('hidden');
 		}
 	);
+
+	// bind the close element
+	const dismiss = formMessage.querySelector('.dismiss');
+	if (dismiss) {
+		dismiss.addEventListener('click', () => {
+			formMessage.classList.add('hidden');
+		});
+	}
 });

--- a/plugin/blocks/src/components/nav/view.js
+++ b/plugin/blocks/src/components/nav/view.js
@@ -1,5 +1,8 @@
 (() => {
 	const windowPath = window.location.pathname.replace(/\/$/, '');
+	if (!windowPath) {
+		return;
+	}
 	document.querySelectorAll('.wp-block-wpcloud-nav a').forEach((link) => {
 		if (link.href?.endsWith(windowPath)) {
 			link.classList.add('contrast');

--- a/plugin/blocks/src/components/ssh-user-list/view.js
+++ b/plugin/blocks/src/components/ssh-user-list/view.js
@@ -1,12 +1,12 @@
 ( ( wpcloud ) => {
-	const updateSshUserInputs = ( sshUserRow ) => {
+	const updateSshUserInputs = (sshUserRow) => {
 		const sshUserInputs = sshUserRow.querySelectorAll(
 			'form input[name=ssh_user]'
 		);
 		const sshUserName = sshUserRow.dataset.siteSshUser;
 		sshUserInputs.forEach( ( input ) => {
 			input.value = sshUserName;
-		});
+		} );
 
 	};
 
@@ -21,16 +21,17 @@
 		.forEach( updateSshUserInputs );
 
 	function onSshUserAdded( { user } ) {
+
 		const newRow = sshUserList
 			.querySelector(
 				'.wpcloud-block-ssh-user-list__row[style*="display:none"]'
 			)
-			.cloneNode( true );
+			.cloneNode(true);
 		newRow.dataset.siteSshUser = user;
 		newRow.querySelector(
 			'.wpcloud-block-site-detail__value'
 		).textContent = user;
-		updateSshUserInputs( newRow );
+		updateSshUserInputs(newRow);
 		newRow.style.display = 'flex';
 		sshUserList.appendChild(newRow);
 
@@ -39,17 +40,54 @@
 		newRow.classList.add('wpcloud-block-ssh-user-list__row--new');
 	}
 
-	function onSshUserRemove( result, form ) {
-		if ( ! result.success ) {
-			alert( result.message ); // eslint-disable-line no-alert, no-undef
+	function onSshUserRemove(result, form) {
+		console.log('onSshUserRemove');
+		if (!result.success) {
+			alert(result.message); // eslint-disable-line no-alert, no-undef
 			return;
 		}
 
-		const row = form.closest( '.wpcloud-block-ssh-user-list__row' );
+		const row = form.closest('.wpcloud-block-ssh-user-list__row');
 
 		row.ontransitionend = row.remove;
 
-		row.classList.add( 'wpcloud-hide' );
+		row.classList.add('wpcloud-hide');
+	}
+
+	function onSshUserUpdate(button) {
+		const sshUser = button.closest(
+			'.wpcloud-block-ssh-user-list__row'
+		);
+
+		const sshUserName = sshUser.dataset.siteSshUser;
+
+		const details = button.closest('details');
+		details && ( details.open = false );
+
+		const form = document.querySelector('.wpcloud-form-ssh-user');
+
+
+		const nameInput = form.querySelector('input[name="user"]');
+		nameInput.value = sshUserName;
+		nameInput.readOnly = true;
+
+		// Clear the other inputs on the form
+		const inputs = form.querySelectorAll('input[type="password"], textarea');
+		inputs.forEach( input => input.value = '' );
+
+		const submit = form.querySelector('button[type="submit"]');
+		submit.querySelector('.wpcloud-block-button__label').textContent =
+			'Update';
+
+		const wpCloudAction = form.querySelector(
+			'input[name="wpcloud_action"]'
+		);
+		wpCloudAction.value = 'site_ssh_user_update';
+
+		// @TODO Open the form section if it's not open already.
+
+		// scroll to the form
+		wpcloud.scrollTo(form).andHighlight('input[name="user"]');
 	}
 
 	wpcloud.hooks.addAction(
@@ -64,10 +102,19 @@
 		onSshUserAdded
 	);
 
+	wpcloud.hooks.addAction(
+		'wpcloud_ssh_user_update_button_click',
+		'wpcloud',
+		onSshUserUpdate
+	);
+
+
 	// Disable the confirmation dialog for removing SSH users.
+	/*
 	wpcloud.hooks.addFilter(
 		'wpcloud_form_should_submit_site_ssh_user_remove',
 		'wpcloud',
 		() => true
 	);
+	*/
 } )( window.wpcloud );

--- a/plugin/blocks/src/components/ssh-user-list/view.js
+++ b/plugin/blocks/src/components/ssh-user-list/view.js
@@ -1,4 +1,7 @@
-( ( wpcloud ) => {
+/**
+ * Wpcloud SSH User List Block.
+ */
+((wpcloud) => {
 	const updateSshUserInputs = (sshUserRow) => {
 		const sshUserInputs = sshUserRow.querySelectorAll(
 			'form input[name=ssh_user]'
@@ -66,6 +69,9 @@
 
 		const form = document.querySelector('.wpcloud-form-ssh-user');
 
+		if (!form) {
+			return;
+		}
 
 		const nameInput = form.querySelector('input[name="user"]');
 		nameInput.value = sshUserName;
@@ -110,11 +116,10 @@
 
 
 	// Disable the confirmation dialog for removing SSH users.
-	/*
 	wpcloud.hooks.addFilter(
 		'wpcloud_form_should_submit_site_ssh_user_remove',
 		'wpcloud',
 		() => true
 	);
-	*/
+
 } )( window.wpcloud );

--- a/plugin/blocks/src/site-ssh-users/view.js
+++ b/plugin/blocks/src/site-ssh-users/view.js
@@ -1,4 +1,7 @@
-( ( wpcloud ) => {
+/**
+ * WP Cloud: Site SSH Users
+ */
+((wpcloud) => {
 	wpcloud.hooks.addAction(
 		'wpcloud_ssh_user_update_button_click',
 		'wpcloud',
@@ -13,10 +16,13 @@
 				'.wpcloud-block-ssh-users'
 			);
 
-			const form = sshUserContainer.querySelector(
-				'.wpcloud-block-form'
-			);
-			const nameInput = form.querySelector( 'input[name="user"]' );
+			const form = sshUserContainer.querySelector('[data-original-action="site_ssh_user_add"]');
+
+			const nameInput = form.querySelector('input[name="user"]');
+			if (!nameInput) {
+				console.error('Could not find the user input field');
+				return;
+			}
 			nameInput.value = sshUserName;
 			nameInput.readOnly = true;
 

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -32,6 +32,19 @@
 	display: none;
 }
 
+.copy-to-clipboard {
+	display: flex;
+  align-items: center;
+  gap: 2px;
+	svg {
+		cursor: pointer;
+		&:hover {
+			filter: brightness(3);
+		}
+	}
+
+}
+
 .wp-block-site-logo img.custom-logo {
 	@media (prefers-color-scheme: light) {
 		filter: brightness(0.4) saturate(1.1) contrast(1.2) hue-rotate(210deg);
@@ -83,6 +96,11 @@ button[type=submit].wpcloud-block-button {
 		* {
 			margin: 0;
 		}
+		svg {
+			&:hover {
+				filter: brightness(3);
+			}
+		}
 	}
 	border: none;
 	&.hide-chevron  {
@@ -123,6 +141,9 @@ button.wpcloud-block-button {
 	.dismiss {
 		cursor: pointer;
 		fill: currentColor;
+		&:hover {
+			filter: brightness(3);
+		}
 	}
 	p {
 		margin: 0;

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -1,3 +1,46 @@
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  }
+  50% {
+    transform: scale(1.1);
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  }
+}
+
+.pulse {
+  animation: pulse 0.5s ease-in-out;
+}
+
+@keyframes hilight {
+  0%, 100% { filter: brightness(0.5); }
+  50% { filter: brightness(2); } /* Lightens the text */
+}
+
+.highlight {
+  animation: hilight 2.5s ease-in-out /*infinite;*/
+  /*animation-iteration-count: 1; */
+}
+
+.hidden {
+	display: none;
+}
+
+.wp-block-site-logo img.custom-logo {
+	@media (prefers-color-scheme: light) {
+		filter: brightness(0.4) saturate(1.1) contrast(1.2) hue-rotate(210deg);
+	}
+	@media (prefers-color-scheme: dark) {
+		/* filter: brightness(1) saturate(1.1) contrast(1.2) hue-rotate(210deg); */
+		filter: invert(25%) sepia(80%) saturate(700%) hue-rotate(190deg) brightness(95%) contrast(100%);
+	}
+}
+
 .wpcloud-block-table-cell--wrapper {
 	white-space: nowrap;
 }
@@ -46,6 +89,34 @@ button[type=submit].wpcloud-block-button {
 		::after {
 			display: none;
 		}
+	}
 
+	&.open-right {
+		ul {
+			right: 0;
+			left: unset;
+		}
+	}
+}
+
+button.wpcloud-block-button {
+	border: 1px solid transparent;
+  background-clip: padding-box;
+}
+.wpcloud-block-button {
+	cursor: pointer;
+}
+
+.wpcloud-block-form {
+	input:read-only, textarea:read-only {
+		background-color: transparent;
+		border: none;
+	}
+}
+
+.wpcloud-form-message {
+	p {
+		margin: 0;
+		color: inherit;
 	}
 }

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -18,13 +18,14 @@
 }
 
 @keyframes hilight {
-  0%, 100% { filter: brightness(0.5); }
-  50% { filter: brightness(2); } /* Lightens the text */
+  50% {
+		filter: brightness(3);
+		transform: scale(1.01);
+	}
 }
 
 .highlight {
-  animation: hilight 2.5s ease-in-out /*infinite;*/
-  /*animation-iteration-count: 1; */
+  animation: hilight 0.5s ease-in-out
 }
 
 .hidden {
@@ -36,7 +37,6 @@
 		filter: brightness(0.4) saturate(1.1) contrast(1.2) hue-rotate(210deg);
 	}
 	@media (prefers-color-scheme: dark) {
-		/* filter: brightness(1) saturate(1.1) contrast(1.2) hue-rotate(210deg); */
 		filter: invert(25%) sepia(80%) saturate(700%) hue-rotate(190deg) brightness(95%) contrast(100%);
 	}
 }

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -115,6 +115,15 @@ button.wpcloud-block-button {
 }
 
 .wpcloud-form-message {
+	&:not(.hidden) {
+		display: flex;
+	}
+	align-items: center;
+	justify-content: space-between;
+	.dismiss {
+		cursor: pointer;
+		fill: currentColor;
+	}
 	p {
 		margin: 0;
 		color: inherit;


### PR DESCRIPTION
This adds a form message block. 
The block has two variants: success and error.
The message is displayed according to the form wpcloud action so it can be placed anywhere on the page.

Pico theme demo:
![Screen Recording 2025-01-23 at 11 36 18 AM](https://github.com/user-attachments/assets/2832d6a9-3a2c-4def-81ce-744a5f0f4b59)

