### PR TITLE
Source client name from persistent data

### DIFF
--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -79,21 +79,24 @@ function wpcloud_settings_init(): void {
 		null,
 		'wpcloud'
 	);
-	add_settings_field(
-		'wpcloud_field_client',
-		__( 'Client Name', 'wpcloud' ),
-		'wpcloud_field_input_cb',
-		'wpcloud',
-		'wpcloud_section_settings',
-		array(
-			'label_for'           => 'wpcloud_client',
-			'class'               => 'wpcloud_row',
-			'wpcloud_custom_data' => 'custom',
-		)
-	);
+
+	if ( ! wpcloud_using_env_settings( 'client_name' ) ) {
+		add_settings_field(
+			'wpcloud_field_client',
+			__( 'Client Name', 'wpcloud' ),
+			'wpcloud_field_input_cb',
+			'wpcloud',
+			'wpcloud_section_settings',
+			array(
+				'label_for'           => 'wpcloud_client',
+				'class'               => 'wpcloud_row',
+				'wpcloud_custom_data' => 'custom',
+			)
+		);
+	}
 
 	// Only show the API key field if it's not set in the environment.
-	if ( ! wpcloud_get_api_key_from_env() ) {
+	if ( ! wpcloud_using_env_settings( 'api_key' ) ) {
 		add_settings_field(
 			'wpcloud_field_api_key',
 			__( 'API Key', 'wpcloud' ),

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -16,13 +16,8 @@ $GLOBALS['wpcloud_client_cache'] = new stdClass();
  * @return string|null Client Name on success. WP_Error on error.
  */
 function wpcloud_get_client_name(): mixed {
-	$wpcloud_settings = get_option( 'wpcloud_settings' );
-
-	if ( ! $wpcloud_settings ) {
-		return null;
-	}
-
-	return $wpcloud_settings['wpcloud_client'] ?? null;
+	$wpcloud_settings = get_option( 'wpcloud_settings', array() );
+	return apply_filters( 'wpcloud_client_name', $wpcloud_settings['wpcloud_client'] ?? null );
 }
 
 /**
@@ -31,12 +26,8 @@ function wpcloud_get_client_name(): mixed {
  * @return string|null Client API Key on success. WP_Error on error.
  */
 function wpcloud_get_client_api_key(): mixed {
-	$api_key = wpcloud_get_api_key_from_env();
-	if ( $api_key ) {
-		return $api_key;
-	}
 	$settings = get_option( 'wpcloud_settings', array() );
-	return $settings['wpcloud_api_key'] ?? null;
+	return apply_filters( 'wpcloud_api_key', $settings['wpcloud_api_key'] ?? null );
 }
 
 /**

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -52,8 +52,6 @@ if ( ! is_admin() ) {
 			);
 		}
 	);
-
-
 }
 
 /**
@@ -67,6 +65,17 @@ function wpcloud_get_api_key_from_env(): string {
 
 	$api_key = apply_filters( 'wpcloud_api_key', $api_key );
 	return $api_key ? $api_key : '';
+}
+
+/**
+ * Check if using environment settings.
+ *
+ * @param string $config_name The config name.
+ * @return bool
+ */
+function wpcloud_using_env_settings( $config_name ): bool {
+	$config = apply_filters( "wpcloud_{$config_name}", '' );
+	return ! empty( $config );
 }
 
 /**


### PR DESCRIPTION
Adds a filter `wpcloud_client_name` to allow setting the client name form other sources
Also cleans up the how the API key is sourced.