### PR TITLE
Webhook proxy option

### DIFF
--- a/plugin/admin/init.php
+++ b/plugin/admin/init.php
@@ -141,7 +141,19 @@ function wpcloud_settings_init(): void {
 			'disabled'        => ! $wpcloud_api_healthy,
 		)
 	);
-
+	add_settings_field(
+		'wpcloud_field_proxy_webhook',
+		__( 'Proxy Webhook URL', 'wpcloud' ),
+		'wpcloud_client_meta_field_input_cb',
+		'wpcloud',
+		'wpcloud_section_settings',
+		array(
+			'label_for'       => 'wpcloud_proxy_webhook_url',
+			'class'           => 'wpcloud_row',
+			'description'     => __( 'The URL to proxy webhook events to.' ),
+			'client_meta_key' => 'proxy_webhook_url',
+		)
+	);
 	/*
 	@TODO Still need to implement the secret key handshake on wp cloud.
 	add_settings_field(

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -265,10 +265,10 @@ function wpcloud_webhook_proxy( $event, $timestamp, $atomic_site_id, $data ): vo
 		return;
 	}
 
-	wp_remote_post(
+	$response = wp_remote_post(
 		$proxy_webhook_url,
 		array(
-			'body' => wp_json_encode(
+			'body'    => wp_json_encode(
 				array(
 					'event'          => $event,
 					'timestamp'      => $timestamp,
@@ -276,8 +276,12 @@ function wpcloud_webhook_proxy( $event, $timestamp, $atomic_site_id, $data ): vo
 					'data'           => $data,
 				)
 			),
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
 		)
 	);
+	wpcloud_l( $response );
 }
 add_action( 'wpcloud_webhook', 'wpcloud_webhook_proxy', 10, 4 );
 

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -251,6 +251,37 @@ function wpcloud_lo( ...$stuff ) {
 }
 
 /**
+ * Proxy webhook to another endpoint.
+ *
+ * @param string $event The event.
+ * @param int    $timestamp The timestamp.
+ * @param string $atomic_site_id The site id.
+ * @param mixed  $data The data.
+ */
+function wpcloud_webhook_proxy( $event, $timestamp, $atomic_site_id, $data ): void {
+	$options           = get_option( 'wpcloud_settings', array() );
+	$proxy_webhook_url = $options['wpcloud_proxy_webhook_url'] ?? '';
+	if ( ! $proxy_webhook_url ) {
+		return;
+	}
+
+	wp_remote_post(
+		$proxy_webhook_url,
+		array(
+			'body' => wp_json_encode(
+				array(
+					'event'          => $event,
+					'timestamp'      => $timestamp,
+					'atomic_site_id' => $atomic_site_id,
+					'data'           => $data,
+				)
+			),
+		)
+	);
+}
+add_action( 'wpcloud_webhook', 'wpcloud_webhook_proxy', 10, 4 );
+
+/**
  * Log to error log. Useful for debugging.
  *
  * @param mixed ...$stuff The stuff to log.


### PR DESCRIPTION
Adds an option to proxy webhooks to a second webhook handler

## Testing 
Run something to catch webhooks like [this](https://github.com/jhnstn/req-catch)

Add a URL to the new `Proxy Webhook` option in the WP Cloud settings

Send a request to the webhook handler in Station, e.g. 
```
curl -X POST "http://localhost:8888/wp-json/wpcloud-station/v1/webhook" \
     -H "Content-Type: application/json" \
     -d '{
       "event": "site_provisioned",
       "timestamp": "1700000000",
       "atomic_site_id": "123456",
       "data": {
         "key1": "value1",
         "key2": "value2"
       }
     }'
```
Verify that the payload is sent to the proxy webhook
![Screen Recording 2025-02-19 at 5 13 51 PM](https://github.com/user-attachments/assets/e18eb80b-7fdf-4fff-b3ea-40b3f658469b)


