### PR TITLE
Prevent webhook loop

### DIFF
--- a/plugin/controllers/class-wpcloud-webhook-controller.php
+++ b/plugin/controllers/class-wpcloud-webhook-controller.php
@@ -58,6 +58,7 @@ if ( ! class_exists( 'WPCLOUD_Webhook_Controller' ) ) {
 			$timestamp       = $params['timestamp'] ?? 0;
 			$wpcloud_site_id = $params['atomic_site_id'] ?? 0;
 			$data            = $params['data'] ?? array();
+			$user_agent      = $request->get_header( 'user-agent' );
 
 			/**
 			 * General action for events.
@@ -67,7 +68,7 @@ if ( ! class_exists( 'WPCLOUD_Webhook_Controller' ) ) {
 			 * @param int    $wpcloud_site_id The WP Cloud Site Id.
 			 * @param array  $data            An array of data sent with the event.
 			 */
-			do_action( 'wpcloud_webhook', $event, $timestamp, $wpcloud_site_id, $data );
+			do_action( 'wpcloud_webhook', $event, $timestamp, $wpcloud_site_id, $data, $user_agent );
 
 			/**
 			 * Specific action for events (e.g. `site_provisioned`, `on-demand-backup`).

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -231,6 +231,43 @@ function wpcloud_station_register_site_view( $view ) {
 }
 
 /**
+ * Proxy an atomic webhook to another endpoint.
+ *
+ * @param string $event The event.
+ * @param int    $timestamp The timestamp.
+ * @param string $atomic_site_id The site id.
+ * @param mixed  $data The data.
+ */
+function wpcloud_webhook_proxy( $event, $timestamp, $atomic_site_id, $data, $user_agent ): void {
+	if ( ! str_starts_with( $user_agent, 'atomic-webhooks' ) ) {
+		return;
+	}
+	$options           = get_option( 'wpcloud_settings', array() );
+	$proxy_webhook_url = $options['wpcloud_proxy_webhook_url'] ?? '';
+	if ( ! $proxy_webhook_url ) {
+		return;
+	}
+
+	wp_remote_post(
+		$proxy_webhook_url,
+		array(
+			'body'    => wp_json_encode(
+				array(
+					'event'          => $event,
+					'timestamp'      => $timestamp,
+					'atomic_site_id' => $atomic_site_id,
+					'data'           => $data,
+				)
+			),
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
+		)
+	);
+}
+add_action( 'wpcloud_webhook', 'wpcloud_webhook_proxy', 10, 5 );
+
+/**
  * Log only once. Useful for debugging.
  *
  * @param mixed ...$stuff The stuff to log.
@@ -251,47 +288,12 @@ function wpcloud_lo( ...$stuff ) {
 }
 
 /**
- * Proxy webhook to another endpoint.
- *
- * @param string $event The event.
- * @param int    $timestamp The timestamp.
- * @param string $atomic_site_id The site id.
- * @param mixed  $data The data.
- */
-function wpcloud_webhook_proxy( $event, $timestamp, $atomic_site_id, $data ): void {
-	$options           = get_option( 'wpcloud_settings', array() );
-	$proxy_webhook_url = $options['wpcloud_proxy_webhook_url'] ?? '';
-	if ( ! $proxy_webhook_url ) {
-		return;
-	}
-
-	$response = wp_remote_post(
-		$proxy_webhook_url,
-		array(
-			'body'    => wp_json_encode(
-				array(
-					'event'          => $event,
-					'timestamp'      => $timestamp,
-					'atomic_site_id' => $atomic_site_id,
-					'data'           => $data,
-				)
-			),
-			'headers' => array(
-				'Content-Type' => 'application/json',
-			),
-		)
-	);
-	wpcloud_l( $response );
-}
-add_action( 'wpcloud_webhook', 'wpcloud_webhook_proxy', 10, 4 );
-
-/**
  * Log to error log. Useful for debugging.
  *
  * @param mixed ...$stuff The stuff to log.
  */
 function wpcloud_l( ...$stuff ) {
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+	if ( ! defined( 'WP_DEBUG_LOG' ) && ! WP_DEBUG_LOG ) {
 		return;
 	}
 	$strings_of_stuff = array();


### PR DESCRIPTION
This checks to see if the webhook request user agent starts with `atomic-webhooks` before forwarding the event.
This prevents loops between two Station sites that are linked by the configures webhook proxy urls