### PR TITLE
Performance Dashboard Mock-up

### DIFF
--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 
 
-export default function Graph({ site, metric, dimension, type, title, interval, refresh, showLegend }) {
+export default function Graph({ site, request_type, metric, dimension, type, title, interval, refresh, showLegend, top_x, resolution, summarize, filters }) {
 	const { start, end } = interval || {};
 	const [ data, setData ] = useState([]);
 	const [ series, setSeries ] = useState([]);
@@ -37,10 +37,15 @@ export default function Graph({ site, metric, dimension, type, title, interval, 
 			try {
 				const { data, series, meta } = await stationApi.get(`metrics/${metric}`, {
 					query: {
+						request_type,
 						site,
 						start,
 						end,
-						dimension
+						dimension,
+						top_x,
+						resolution,
+						summarize,
+						filters,
 					}, parse: true, signal
 				});
 				setData(data);

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 
 
-export default function Graph({ site, request_type, metric, dimension, type, title, interval, refresh, showLegend, top_x, resolution, summarize, filters }) {
+export default function Graph({ site, request_type, metric, dimension, type, title, interval, refresh, showLegend, top_x, resolution, summarize, filters, displayClass }) {
 	const { start, end } = interval || {};
 	const [ data, setData ] = useState([]);
 	const [ series, setSeries ] = useState([]);
@@ -63,11 +63,16 @@ export default function Graph({ site, request_type, metric, dimension, type, tit
 		return () => controller.abort();
 	}, [ site, metric, start, end, refresh ] );
 
+	if ( typeof displayClass === 'string' || displayClass instanceof String ) {
+		//
+	} else {
+		displayClass = 'graph-100';
+	}
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type });
 	const hasData = data.length > 0;
 	return (
-		<div ref={containerRef} className="wpcloud-graph" style={{ width: "100%", height: "500px", backgroundColor: "white", position: "relative" }}>
+		<div ref={containerRef} className={`wpcloud-graph ${displayClass}`} style={{ backgroundColor: "white", position: "relative" }}>
 			{ loading && <Loader />}
 			{ hasData && <UplotReact
 				options={options}

--- a/plugin/blocks/src/components/graph/components/lib/options.js
+++ b/plugin/blocks/src/components/graph/components/lib/options.js
@@ -50,6 +50,20 @@ function withDefaultOptions(opts) {
 	};
 }
 
+function withHorizontalOptions(opts) {
+	return {
+		padding: [null, 0, null, 0],
+		//ori: 0,
+		axes: [{ side: 3 }, { side: 0}],
+		legend: { live: false, markers: { width: 2 } },
+		scales: {
+			y: { range: [0, null], ori: 0, dir: 1 },
+			x: { ori: -1, dir: 1 }
+		},
+		...opts
+	};
+}
+
 
 function scaleFunc(options) {
  	const { series, useStatus = false, seriesOptions = {} } = options;
@@ -70,6 +84,13 @@ export function barOptions({ series:s, useStatus, seriesOptions, ...options }) {
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
 	return withDefaultOptions({ series, plugins, ...options });
+}
+
+export function horizontalBarOptions({ series:s, useStatus, seriesOptions, ...options }) {
+	const plugins = [seriesBarsPlugin()];
+	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
+	const series = buildSeries(s, { fillScale, ...seriesOptions });
+	return withHorizontalOptions({ series, plugins, ...options });
 }
 
 export function lineOptions({ series, useStatus, seriesOptions, ...options }) {

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import croma from 'chroma-js';
-import { stackedOptions, defaultOptions, barOptions, lineOptions, areaOptions } from './options';
+import { stackedOptions, defaultOptions, barOptions, horizontalBarOptions, lineOptions, areaOptions } from './options';
 
 // Remove this amount from the container height to fit the graph legend.
 const fitGraphHeight = 75;
@@ -65,6 +65,10 @@ export default (options) => {
 		case 'bar':
 			seriesOptions = { fillScale: () => croma('blue') };
 			return barOptions({ ...graphOptions, seriesOptions });
+
+		case 'horizontal-bar':
+			seriesOptions = { fillScale: () => croma('blue') };
+			return horizontalBarOptions({ ...graphOptions, seriesOptions });
 
 		case 'line':
 			seriesOptions = { points: { show: false } };

--- a/plugin/blocks/src/metrics/view.js
+++ b/plugin/blocks/src/metrics/view.js
@@ -9,7 +9,11 @@ import { createRoot } from 'react-dom/client';
 import Metrics from './components/metrics.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-	const siteId = wpcloudSite?.id;
+	var _siteId = null;
+	if( typeof wpcloudSite !== 'undefined' ) {
+		_siteId = wpcloudSite?.id;
+	}
+	const siteId = _siteId;
 	const container = document.getElementById('metrics');
 	const graphs = Array.from(container.querySelectorAll('.wp-block-wpcloud-graph')).map((graph) => {
 		const data = JSON.parse(graph.dataset.graphAttributes);

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -50,7 +50,45 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 					'args'                => array(
 						'site'      => array(
 							'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
-							'type'        => 'integer',
+							'type'        => 'string',
+							'options'     => array(
+								'default' => 0,
+							),
+						),
+						'resolution'      => array(
+							'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
+							'type'        => 'int',
+							'options'     => array(
+								'default' => 0,
+							),
+						),
+						'top_x'      => array(
+							'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
+							'type'        => 'int',
+							'options'     => array(
+								'default' => 0,
+							),
+						),
+						'filters'	=> array(
+							'description' => esc_html__( 'Filters to be applied to the metric query', 'wpcloud' ),
+							'type'        => 'string', // This is an associated array but to make it easier to handle accept json_encoded( array ) aka string
+							'options'     => array(
+								'default' => null,
+							),
+						),
+						'summarize'      => array(
+							'description' => esc_html__( 'Retrieve a summary vs time based results', 'wpcloud' ),
+							'type'        => 'boolean',
+							'options'     => array(
+								'default' => false,
+							),
+						),
+						'request_type' => array(
+							'description' => esc_html__( 'Type of Metric Request.', 'wpcloud' ),
+							'type'        => 'string',
+							'options'     => array(
+								'default' => 'site',
+							)
 						),
 						'metric'    => array(
 							'description' => esc_html__( 'The metric to retrieve.', 'wpcloud' ),
@@ -105,21 +143,37 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		 * @return WP_REST_Response
 		 */
 		public function get_site_metric( WP_REST_Request $request ): WP_REST_Response {
+
 			$params    = $request->get_params();
+
 			$site_id   = $params['site'];
 			$metric    = $params['metric'];
+			$request_type = $params['request_type'];
+			$resolution = isset( $params['resolution'] ) ? intval( $params['resolution'] ) : 10;
+			$top_x     = isset( $params['top_x'] ) ? intval( $params['top_x'] ) : 20;
 			$dimension = $params['dimension'] ?? null;
 			$start     = $this->parseTime( $params['start'] ?? null, 'start' );
 			$end       = $this->parseTime( $params['end'] ?? null, 'end' );
+			$summarize = isset( $params['summarize'] ) ? true : false;
+
+			$filters = $params['filters'] ?? null;
+			if ( ! empty ( $filters ) ) {
+				// TODO - validation and error handling, change in type?
+				$filters = json_decode( urldecode( $filters ) );
+			}
 
 			if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
 				return new WP_REST_Response( $start->get_error_message(), 400 );
 			}
 
-			$site = WPCLOUD_Site::get_by_id( $site_id );
+			if ( $site_id > 0 ) {
+				$site = WPCLOUD_Site::get_by_id($site_id);
 
-			if ( ! $site ) {
-				return new WP_REST_Response( esc_html__( 'Site not found', 'wpcloud' ), 404 );
+				if (!$site) {
+					return new WP_REST_Response(esc_html__('Site not found', 'wpcloud'), 404);
+				}
+			} else {
+				$site_id = 0;
 			}
 
 			$view = WPCLOUD_Metric_Data_View::load(
@@ -128,6 +182,11 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				dimension: $dimension,
 				start: $start,
 				end: $end,
+				request_type: $request_type,
+				resolution: $resolution,
+				top_x: $top_x,
+				summarize: $summarize,
+				filters: $filters,
 			);
 
 			if ( is_wp_error( $view ) ) {
@@ -135,7 +194,9 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 			}
 
 			$result = $view->default();
-
+			if ( is_wp_error( $result ) ) {
+				return new WP_REST_Response( $result->get_error_message(), 500 );
+			}
 			$response = array(
 				'meta'   => $result->meta,
 				'series' => $result->series,

--- a/plugin/includes/class-wpcloud-metric-data-view.php
+++ b/plugin/includes/class-wpcloud-metric-data-view.php
@@ -53,7 +53,7 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 	 *
 	 * @return WP_Error|WPCLOUD_Metric_Data
 	 */
-	public static function load( int $site, string $metric, string $dimension, int $start, int $end ): WP_Error|WPCLOUD_Metric_Data_View {
+	public static function load( int $site, string $metric, string $dimension, int $start, int $end, string $request_type = 'site', int $resolution = 10, int $top_x = 20, bool $summarize = false, array $filters = null ): WP_Error|WPCLOUD_Metric_Data_View {
 		// validate the metric and dimension.
 		$view = new self( $site, $metric, $dimension, $start, $end );
 		if ( ! array_key_exists( $view->metric, $view->get_available_metrics() ) ) {
@@ -63,8 +63,13 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 		if ( ! array_key_exists( $view->dimension, $view->get_available_dimensions() ) ) {
 			return new WP_Error( 'invalid_dimension', 'Invalid dimension', array( 'status' => 400 ) );
 		}
-
-		$view->fetch();
+		$view->fetch( [
+			'request_type' => $request_type,
+			'resolution' => $resolution,
+			'top_x' => $top_x,
+			'summarize' => $summarize,
+			'filters' => $filters,
+		] );
 		if ( is_wp_error( $view->result ) ) {
 			return $view->result;
 		}

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -15,6 +15,13 @@ require_once __DIR__ . '/wpcloud-client.php';
 class WPCloud_Metrics {
 
 	/**
+	 * Client ID or Name
+	 *
+	 * @var string
+	 */
+	protected string $client;
+
+	/**
 	 * The site.
 	 *
 	 * @var int
@@ -97,6 +104,11 @@ class WPCloud_Metrics {
 		$this->dimension = $dimension;
 		$this->start     = $start ?? strtotime( '-24 hours' );
 		$this->end       = $end ?? time();
+
+		// TODO - Is this already available without option lookup?
+		$options = get_option( 'wpcloud_settings' );
+		$this->client = $options['wpcloud_client'] ?? null;
+
 	}
 
 	/**
@@ -173,11 +185,18 @@ class WPCloud_Metrics {
 			),
 			$options
 		);
-
-		$this->result = wpcloud_client_site_metrics( $this->site, $this->start, $this->end, $options );
+		// TODO - Hack to switch endpoint as same metrics can be pulled per client or site
+		if ( $options['request_type'] == 'client' ) {
+			unset( $options['type'] );
+			$this->result = wpcloud_client_metrics( $this->client, $this->start, $this->end, $options );
+		} else {
+			unset( $options['type'] );
+			$this->result = wpcloud_client_site_metrics($this->site, $this->start, $this->end, $options);
+		}
 		if ( is_wp_error( $this->result ) ) {
 			return $this->result;
 		}
+
 		$this->meta    = (array) $this->result->_meta;
 		$this->periods = json_decode( wp_json_encode( $this->result->periods ), true );
 		return $this;

--- a/plugin/includes/wpcloud-client.php
+++ b/plugin/includes/wpcloud-client.php
@@ -930,7 +930,7 @@ function wpcloud_client_site_logs( int $wpcloud_site_id, ?int $start, ?int $end,
  * @return stdClass|WP_Error Site metrics on success. WP_Error on error.
  */
 function wpcloud_client_site_metrics( int $wpcloud_site_id, int $start, int $end, $options = array() ): stdClass|WP_Error {
-	$endpoint = "site-metrics/$wpcloud_site_id";
+	$endpoint = "metrics/site/$wpcloud_site_id";
 	if ( isset( $options['summarize'] ) && $options['summarize'] ) {
 		$endpoint .= '/summarize/';
 		unset( $options['summarize'] );
@@ -944,6 +944,34 @@ function wpcloud_client_site_metrics( int $wpcloud_site_id, int $start, int $end
 	);
 	return wpcloud_client_post( $wpcloud_site_id, $endpoint, $args );
 }
+
+/**
+ * Fetch the site metrics.
+ *
+ * @param string|integer $wpcloud_client_id_or_name  The WP Cloud Client ID or Name.
+ * @param integer $start           The start time of the metrics to fetch.
+ * @param integer $end             The end time of the metrics to fetch.
+ * @param array   $options         Optional. Additional options for the metrics query.
+ *
+ * @return stdClass|WP_Error Site metrics on success. WP_Error on error.
+ */
+function wpcloud_client_metrics( $wpcloud_client_id_or_name, int $start, int $end, $options = array() ): stdClass|WP_Error {
+	$endpoint = "metrics/client/$wpcloud_client_id_or_name";
+	if ( isset( $options['summarize'] ) && $options['summarize'] ) {
+		$endpoint .= '/summarize/';
+	}
+	unset( $options['summarize'] );
+	$args = wp_parse_args(
+		$options,
+		array(
+			'start' => $start,
+			'end'   => $end,
+		)
+	);
+
+	return wpcloud_client_post( null, $endpoint, $args );
+}
+
 /**
  * Make a GET request the WP Cloud API.
  *

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -373,6 +373,31 @@ button.wpcloud-block-button {
 	margin: 20px 0;
 }
 
+.wpcloud-graph  {
+	width: 100%;
+	height: 500px;
+	vertical-align: top;
+}
+
+.wpcloud-graph.graph-tall {
+	height: 1000px;
+}
+
+/* Styling for Graph Layouts */
+@media(min-width: 1024px) {
+	.wpcloud-graph.graph-50 {
+		display: inline-block;
+		width: calc(50% - 10px);
+		margin-right: 10px;
+	}
+
+	.wpcloud-graph.graph-33 {
+		display: inline-block;
+		width: calc(33.33% - 10px);
+		margin-right: 10px;
+	}
+}
+
 .wp-block-site-logo.hero-logo {
 	display: flex;
 	margin: 0 20px;

--- a/theme-pico/templates/performance-dashboard-wpcloud.html
+++ b/theme-pico/templates/performance-dashboard-wpcloud.html
@@ -1,0 +1,48 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","area":"header"} /-->
+
+<!-- wp:spacer {"height":"12px","className":"wpcloud-site-view\u002d\u002dcontent\u002d\u002dspacer"} -->
+<div style="height:12px" aria-hidden="true" class="wp-block-spacer wpcloud-site-view--content--spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:columns {"className":"wpcloud-site-view\u002d\u002dcontent"} -->
+<div class="wp-block-columns wpcloud-site-view--content"><!-- wp:column {"width":""} -->
+	<div class="wp-block-column">
+<!-- /wp:column -->
+
+<!-- wp:wpcloud/metrics -->
+<div class="wp-block-wpcloud-metrics" id="metrics"><!-- wp:group {"metadata":{"name":"Graphs"},"className":"wpcloud-metrics","layout":{"type":"grid","columnCount":2,"minimumColumnWidth":null}} -->
+	<div class="wp-block-group wpcloud-metrics"><!-- wp:wpcloud/graph {"type":"bar"} -->
+
+		<!-- 'requests', 'http_status' -->
+		<!-- We want a stacked bar chart see: https://github.com/leeoniya/uPlot/blob/211f06d6d258833d025952e890a612b254b0a9fb/demos/bars-grouped-stacked.html -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_status&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;stacked&quot;:&quot;true&quot;,&quot;title&quot;:&quot;Requests by HTTP Response Code&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
+		<!-- 'response_time_average', 'http_verb' -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;response_time_average&quot;,&quot;dimension&quot;:&quot;http_verb&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;HTTP Response Time&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
+
+		<!-- Top X Bars -->
+		<!-- Top 20 Sites by Request -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 20 Sites by Requests&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:20,&quot;summarize&quot;:true}">Graph</div>
+
+		<!-- Top 10 Resource-Limited Sites (599) -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 10 Resource-Limited Sites (599)&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3D%22%2C%22value%22%3A429%7D%5D&quot;,&quot;summarize&quot;:true}">Graph</div>
+
+		<!-- Top 10 Sites with 5XX -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 10 Sites with 5XX&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;summarize&quot;:true,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3E%3D%22%2C%22value%22%3A500%7D%2C%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3C%22%2C%22value%22%3A600%7D%5D&quot;}">Graph</div>
+
+
+		<!-- 'php_cpu_time_persec', 'http_host' -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;php_cpu_time_persec&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;Top 10 Sites by CPU Cores&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60,&quot;top_x&quot;:10}">Graph</div>
+
+		<!-- 'php_response_time_sum', 'http_host' -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;php_response_time_sum&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;Top 10 Sites by Request Time&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:300,&quot;top_x&quot;:10}">Graph</div>
+
+		<!-- 'response_bytes', 'http_host' -->
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;response_bytes&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;Top 10 Sites by Bandwidth&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:300,&quot;top_x&quot;:10}">Graph</div>
+
+
+	</div><!-- /wp:group -->
+</div><!-- /wp:wpcloud/metrics -->
+</div><!-- /wp:column -->
+</div><!-- /wp:columns -->
+
+<!-- wp:template-part {"slug":"footer","area":"footer","className":"wpcloud-footer"} /-->

--- a/theme-pico/templates/performance-dashboard-wpcloud.html
+++ b/theme-pico/templates/performance-dashboard-wpcloud.html
@@ -5,7 +5,7 @@
 <!-- /wp:spacer -->
 
 <!-- wp:columns {"className":"wpcloud-site-view\u002d\u002dcontent"} -->
-<div class="wp-block-columns wpcloud-site-view--content"><!-- wp:column {"width":""} -->
+<div class="wp-block-columns">
 	<div class="wp-block-column">
 <!-- /wp:column -->
 
@@ -15,19 +15,21 @@
 
 		<!-- 'requests', 'http_status' -->
 		<!-- We want a stacked bar chart see: https://github.com/leeoniya/uPlot/blob/211f06d6d258833d025952e890a612b254b0a9fb/demos/bars-grouped-stacked.html -->
-		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_status&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;stacked&quot;:&quot;true&quot;,&quot;title&quot;:&quot;Requests by HTTP Response Code&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
+		<div class="wp-block-wpcloud-graph " data-graph-attributes="{&quot;displayClass&quot;:&quot;graph-50&quot;,&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_status&quot;,&quot;type&quot;:&quot;stacked-bar&quot;,&quot;stacked&quot;:&quot;true&quot;,&quot;title&quot;:&quot;Requests by HTTP Response Code&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
+
 		<!-- 'response_time_average', 'http_verb' -->
-		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;response_time_average&quot;,&quot;dimension&quot;:&quot;http_verb&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;HTTP Response Time&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;displayClass&quot;:&quot;graph-50&quot;,&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;response_time_average&quot;,&quot;dimension&quot;:&quot;http_verb&quot;,&quot;type&quot;:&quot;line&quot;,&quot;title&quot;:&quot;HTTP Response Time&quot;,&quot;showLegend&quot;:true,&quot;resolution&quot;:60}">Graph</div>
 
 		<!-- Top X Bars -->
+
 		<!-- Top 20 Sites by Request -->
-		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 20 Sites by Requests&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:20,&quot;summarize&quot;:true}">Graph</div>
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;displayClass&quot;:&quot;graph-50 graph-tall&quot;,&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;horizontal-bar&quot;,&quot;title&quot;:&quot;Top 20 Sites by Requests&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:20,&quot;summarize&quot;:true}">Graph</div>
 
 		<!-- Top 10 Resource-Limited Sites (599) -->
-		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 10 Resource-Limited Sites (599)&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3D%22%2C%22value%22%3A429%7D%5D&quot;,&quot;summarize&quot;:true}">Graph</div>
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;displayClass&quot;:&quot;graph-50&quot;,&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;horizontal-bar&quot;,&quot;title&quot;:&quot;Top 10 Resource-Limited Sites (599)&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3D%22%2C%22value%22%3A429%7D%5D&quot;,&quot;summarize&quot;:true}">Graph</div>
 
 		<!-- Top 10 Sites with 5XX -->
-		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Top 10 Sites with 5XX&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;summarize&quot;:true,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3E%3D%22%2C%22value%22%3A500%7D%2C%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3C%22%2C%22value%22%3A600%7D%5D&quot;}">Graph</div>
+		<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;displayClass&quot;:&quot;graph-50&quot;,&quot;site&quot;:0,&quot;request_type&quot;:&quot;client&quot;,&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_host&quot;,&quot;type&quot;:&quot;horizontal-bar&quot;,&quot;title&quot;:&quot;Top 10 Sites with 5XX&quot;,&quot;showLegend&quot;:true,&quot;top_x&quot;:10,&quot;summarize&quot;:true,&quot;filters&quot;:&quot;%5B%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3E%3D%22%2C%22value%22%3A500%7D%2C%7B%22column%22%3A%22http_status%22%2C%22operator%22%3A%22%3C%22%2C%22value%22%3A600%7D%5D&quot;}">Graph</div>
 
 
 		<!-- 'php_cpu_time_persec', 'http_host' -->


### PR DESCRIPTION
@jhnstn Jason, this is the draft of the Client Performance Dashboard that I was hacking at earlier in the week. There are a few items that I could use assistance on as time allows.

1) The first graph should be a stacked bar chart.  Like in your Metrics POC post. Is this styling not in trunk? 
<img width="424" alt="Screenshot 2025-04-03 at 3 07 37 PM" src="https://github.com/user-attachments/assets/42fa6f0e-bf01-4f57-86e8-1fc3b04e627b" />

2) The 3 graphs in Top X section ideally would be a horizontal bar chart. 

3) We need better handling of empty data sets. I see that the 500 response is currently returned we should have a default graphic to show in these cases Data Unavailable or something. 

4) Its been awhile since I touched react. I added in parameters for the different options needed for the graphs some notes on each.
filters -> Currently I'm using urlencoded json as that was a quick way to add in the functionality I needed. How do you recommend an associated array be defined in the template and passed up the stack?
request_type -> site vs client.  Probably a better name needed here :)

5) Thoughts on better handling of siteId, I used request_type to remove it but we should allow it to be passed vs inferred from the page context. Especially if we want to have a drill down view from Client to Site dashboard and not be dependent on all sites being in the station instance and linking back to a post_id.

6) General Page Styling. Spacing around individual graphs, columns layouts? 

I'm going to work on this more tomorrow (hopefully) in flushing out some other views to see what other options aren't accounted for. We can discuss here or P2. I just wanted to capture the current state.
