### PR TITLE
Blocks: Update form submit

### DIFF
--- a/plugin/blocks/src/components/form/view.js
+++ b/plugin/blocks/src/components/form/view.js
@@ -36,7 +36,8 @@
 			data[input.name] = input.value;
 		});
 
-		form.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+		// grab any checkboxes that are not submit on change
+		form.querySelectorAll('input[type="checkbox"]:not(.submit-on-change)').forEach((input) => {
 			data[input.name] = input.checked ? 1 : 0;
 		});
 

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -519,7 +519,7 @@ class WPCLOUD_Site {
 				'options' => array(
 					''         => '',
 					'staging'  => __( 'Staging' ),
-					'billable'  => __( 'Billable' ),
+					'billable' => __( 'Billable' ),
 					'internal' => __( 'Internal' ),
 				),
 				'hint'    => __( 'Site data' ),
@@ -669,11 +669,16 @@ class WPCLOUD_Site {
 					if ( ! $site_meta->is_ok() ) {
 						return '';
 					}
-					return $site_meta->data->$key ?? null;
+					return $site_meta->data ?? null;
 
 				case 'edge_cache_status':
 					$edge_cache = $api_client->get( 'edge-cache/:site_id' );
 					return $edge_cache->status;
+
+				// These can just fall through.
+				case 'edge_cache_purge':
+				case 'edge_cache_toggle':
+					return '';
 
 				case 'defensive_mode':
 					$edge_cache = $api_client->get( 'edge-cache/:site_id' );

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -645,7 +645,7 @@ class WPCLOUD_Site {
 				case 'space_quota':
 				case 'max_space_quota':
 					$site_meta   = $api_client->get( "site-meta/:site_id/$key/get" );
-					$space_value = $site_meta->data->$key ?? 0;
+					$space_value = $site_meta->data ?? 0;
 					return self::readable_size( (float) $space_value );
 
 				case 'site_access_with_ssh':
@@ -669,7 +669,7 @@ class WPCLOUD_Site {
 					if ( ! $site_meta->is_ok() ) {
 						return '';
 					}
-					return $site_meta->data ?? null;
+					return $site_meta->data ?? '';
 
 				case 'edge_cache_status':
 					$edge_cache = $api_client->get( 'edge-cache/:site_id' );

--- a/plugin/tests/test-wpcloud-site.php
+++ b/plugin/tests/test-wpcloud-site.php
@@ -267,19 +267,19 @@ class WPCloud_SiteTest extends WP_UnitTestCase {
 		$about_a_gig = 1073741824;
 		Mock_Helper::mock_api_requests(
 			array(
-				'site-meta/123/space_used/get'   => (object) array(
-					'data' => (object) array(
-						'space_used' => $about_a_gig,
-					),
+				'site-meta/123/space_used/get'      => (object) array(
+					'data' => $about_a_gig,
 				),
-				'site-meta/123/db_file_size/get' => (object) array(
-					'data' => (object) array(
-						'db_file_size' => $about_a_gig,
-					),
+				'site-meta/123/db_file_size/get'    => (object) array(
+					'data' => $about_a_gig,
 				),
 				// Check for empty values.
-				'site-meta/123/space_quota/get'  => (object) array(
-					'data' => (object) array(),
+				'site-meta/123/space_quota/get'     => (object) array(
+					'data' => '',
+				),
+				// Test other site meta.
+				'site-meta/123/burst_php_conns/get' => (object) array(
+					'data' => '6',
 				),
 			)
 		);
@@ -289,6 +289,10 @@ class WPCloud_SiteTest extends WP_UnitTestCase {
 		}
 		$no_value = WPCloud_Site::get_detail( $this->post, 'space_quota' );
 		$this->assertEquals( '0 B', $no_value );
+
+		// Test that raw metadata is returned correctly.
+		$burst_php_conns = WPCloud_Site::get_detail( $this->post, 'burst_php_conns' );
+		$this->assertEquals( '6', $burst_php_conns );
 
 		// Check edge cache.
 		Mock_Helper::mock_api_request(


### PR DESCRIPTION
Fixes #306 

The form block shouldn't submit checkbox inputs when set as submit on change.
Also the site details was not accessing the response data correctly.
