### PR TITLE
Block: Add type to the Metrics block

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -311,6 +311,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y subversion
 
+      - name: Wait for MySQL to be ready
+        run: |
+          # Wait for MySQL to be ready
+          for i in {1..30}; do
+            if mysql -h127.0.0.1 -uroot -proot -e 'SELECT 1;' &> /dev/null; then
+              echo "MySQL is ready!"
+              break
+            fi
+            echo "Waiting for MySQL to be ready... ($i/30)"
+            sleep 2
+          done
+
+          # Verify the MySQL connection
+          mysql -h127.0.0.1 -uroot -proot -e 'SELECT 1;'
+
       - name: Set up WordPress test suite
         run: |
           # Create verbose logging flag file if needed
@@ -318,9 +333,6 @@ jobs:
 
           # Install the WordPress test suite
           bash plugin/bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest true
-
-          # Verify the MySQL connection
-          mysql -h127.0.0.1 -uroot -proot -e 'SELECT 1;'
 
       - name: Run PHPUnit tests
         working-directory: ./plugin

--- a/plugin/bin/install-wp-tests.sh
+++ b/plugin/bin/install-wp-tests.sh
@@ -140,7 +140,26 @@ recreate_db() {
 }
 
 create_db() {
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	# Try to create the database with retries
+	local max_retries=5
+	local retry_count=0
+	local success=false
+
+	while [ $retry_count -lt $max_retries ] && [ "$success" = "false" ]; do
+		if mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA; then
+			success=true
+			echo "Database created successfully."
+		else
+			retry_count=$((retry_count+1))
+			if [ $retry_count -lt $max_retries ]; then
+				echo "Failed to create database. Retrying in 5 seconds... (Attempt $retry_count of $max_retries)"
+				sleep 5
+			else
+				echo "Failed to create database after $max_retries attempts."
+				return 1
+			fi
+		fi
+	done
 }
 
 install_db() {
@@ -165,12 +184,42 @@ install_db() {
 		fi
 	fi
 
-	# create database
-	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
-	then
-		echo "Reinstalling will delete the existing test database ($DB_NAME)"
-		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
-		recreate_db $DELETE_EXISTING_DB
+	# Check if database exists with retries
+	local max_retries=5
+	local retry_count=0
+	local db_exists=false
+	local check_success=false
+
+	while [ $retry_count -lt $max_retries ] && [ "$check_success" = "false" ]; do
+		if db_list=$(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' 2>/dev/null); then
+			check_success=true
+			if echo "$db_list" | grep -q "^$DB_NAME$"; then
+				db_exists=true
+			fi
+		else
+			retry_count=$((retry_count+1))
+			if [ $retry_count -lt $max_retries ]; then
+				echo "Failed to check if database exists. Retrying in 5 seconds... (Attempt $retry_count of $max_retries)"
+				sleep 5
+			else
+				echo "Failed to check if database exists after $max_retries attempts."
+				echo "Proceeding with database creation anyway..."
+			fi
+		fi
+	done
+
+	# Create or recreate database
+	if [ "$db_exists" = "true" ] && [ "$check_success" = "true" ]; then
+		if [ -t 0 ]; then
+			# Running in interactive mode, ask for confirmation
+			echo "Reinstalling will delete the existing test database ($DB_NAME)"
+			read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+			recreate_db $DELETE_EXISTING_DB
+		else
+			# Running in non-interactive mode (CI), proceed with recreation
+			echo "Recreating existing database ($DB_NAME) without confirmation (non-interactive mode)"
+			recreate_db "y"
+		fi
 	else
 		create_db
 	fi

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 
 
-export default function Graph({ site, metric, dimension, type, title, interval, refresh, showLegend }) {
+export default function Graph({ apiPath, metric, dimension, type, title, interval, refresh, showLegend }) {
 	const { start, end } = interval || {};
 	const [ data, setData ] = useState([]);
 	const [ series, setSeries ] = useState([]);
@@ -35,9 +35,8 @@ export default function Graph({ site, metric, dimension, type, title, interval, 
 		setLoading(true);
 		async function fetchData() {
 			try {
-				const { data, series, meta } = await stationApi.get(`metrics/site/${metric}`, {
+				const { data, series, meta } = await stationApi.get( apiPath, {
 					query: {
-						site,
 						start,
 						end,
 						dimension
@@ -56,7 +55,7 @@ export default function Graph({ site, metric, dimension, type, title, interval, 
 
 		fetchData();
 		return () => controller.abort();
-	}, [ site, metric, start, end, refresh ] );
+	}, [ metric, start, end, refresh ] );
 
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type });

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 
 
-export default function Graph({ apiPath, metric, dimension, type, title, interval, refresh, showLegend }) {
+export default function Graph({ apiPath, dimension, type, title, interval, refresh, showLegend }) {
 	const { start, end } = interval || {};
 	const [ data, setData ] = useState([]);
 	const [ series, setSeries ] = useState([]);
@@ -55,7 +55,7 @@ export default function Graph({ apiPath, metric, dimension, type, title, interva
 
 		fetchData();
 		return () => controller.abort();
-	}, [ metric, start, end, refresh ] );
+	}, [ apiPath,start, end, refresh ] );
 
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type });

--- a/plugin/blocks/src/metrics/block.json
+++ b/plugin/blocks/src/metrics/block.json
@@ -23,6 +23,10 @@
 		"id": {
 			"type": "string",
 			"default": "metrics"
+		},
+		"type": {
+			"type": "string",
+			"default": "client"
 		}
 	}
 }

--- a/plugin/blocks/src/metrics/components/metrics.js
+++ b/plugin/blocks/src/metrics/components/metrics.js
@@ -37,7 +37,7 @@ function Metrics({ graphs, site }) {
 	const interval = { start, end };
 
 	const graphComponents = graphs.map((graph, index) => {
-		return <Graph key={index} {...graph} site={site} interval={interval} refresh={ toggleRefresh } />;
+		return <Graph key={index} {...graph} interval={interval} refresh={ toggleRefresh } />;
 	});
 
 	const onRefresh = () => {

--- a/plugin/blocks/src/metrics/index.js
+++ b/plugin/blocks/src/metrics/index.js
@@ -3,31 +3,68 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks, useBlockProps  } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	TextControl,
+	ToggleControl,
+	SelectControl,
+	Spinner
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import {  updateAttribute } from '@wpcloud/controls';
 import metadata from './block.json';
 
-const template = [
-	['core/group',
-		{
-			className: 'wpcloud-metrics',
-			metadata: {
-				name: 'Graphs',
+function edit( {attributes, setAttributes } ) {
+	const update = updateAttribute(setAttributes);
+	const blockProps = useBlockProps();
+
+	const template = [
+		['core/group',
+			{
+				className: 'wpcloud-metrics',
+				metadata: {
+					name: 'Graphs',
+				},
+				layout: {
+					type: "grid",
+					columnCount: 2,
+					minimumColumnWidth: null
+				},
 			},
-			layout: {
-				type: "grid",
-				columnCount: 2,
-				minimumColumnWidth: null
-			},
-		},
-		[],
-	],
-];
+			[],
+		],
+	];
+
+	const controls = (
+		<InspectorControls>
+			<PanelBody title={__('Metrics Settings')}>
+				<SelectControl
+					label={__('Type')}
+					value={attributes.type}
+					options={[
+						{ label: 'Client', value: 'client' },
+						{ label: 'Site', value: 'site' },
+					]}
+					onChange={ update( 'type' ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	)
+
+
+	return (
+		<div {...blockProps}>
+			{controls}
+			<InnerBlocks template={template} />
+		</div>
+	);
+}
 
 registerBlockType( metadata.name, {
-	edit: () => <InnerBlocks template={template} />,
-	save: ({ attributes }) => <div {...useBlockProps.save()} id={attributes.id || 'metrics' }><InnerBlocks.Content /></div>
+	edit,
+	save: ({ attributes }) => <div {...useBlockProps.save()} id={attributes.id || 'metrics' } data-metrics-attributes={JSON.stringify(attributes)}><InnerBlocks.Content /></div>
 } );

--- a/plugin/blocks/src/metrics/view.js
+++ b/plugin/blocks/src/metrics/view.js
@@ -9,14 +9,30 @@ import { createRoot } from 'react-dom/client';
 import Metrics from './components/metrics.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-	const siteId = wpcloudSite?.id;
 	const container = document.getElementById('metrics');
+	const metricsAttributes = container.dataset.metricsAttributes;
+	if ( !metricsAttributes ) {
+		console.error('No metrics attributes found in the container.');
+		return;
+	}
+	const { type } = JSON.parse(metricsAttributes);
+	let apiPath = `metrics/${type}`;
+	if ( 'site' == type ) {
+		const siteId = window.wpcloudSite?.id;
+		if ( ! siteId ) {
+			console.error( 'No site ID found in the window object.' );
+			return;
+		}
+
+		apiPath += `/${siteId}`;
+	}
 	const graphs = Array.from(container.querySelectorAll('.wp-block-wpcloud-graph')).map((graph) => {
 		const data = JSON.parse(graph.dataset.graphAttributes);
+		data.apiPath = apiPath;
 		graph.parentNode?.removeChild(graph);
 		return data;
 	});
 
 	const root = createRoot(container);
-	root.render(<Metrics graphs={graphs} site={siteId} />);
+	root.render(<Metrics graphs={graphs} />);
 });

--- a/plugin/blocks/src/metrics/view.js
+++ b/plugin/blocks/src/metrics/view.js
@@ -28,7 +28,12 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 	const graphs = Array.from(container.querySelectorAll('.wp-block-wpcloud-graph')).map((graph) => {
 		const data = JSON.parse(graph.dataset.graphAttributes);
-		data.apiPath = apiPath;
+		const { metric } = data;
+		if ( ! metric ) {
+			console.error('No metric found in the graph attributes.');
+			return null;
+		}
+		data.apiPath = `${apiPath}/${metric}`;
 		graph.parentNode?.removeChild(graph);
 		return data;
 	});

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -43,35 +43,43 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				)
 			);
 
+			$common_args = array(
+				'metric'    => array(
+					'description' => esc_html__( 'The metric to retrieve.', 'wpcloud' ),
+					'type'        => 'string',
+				),
+				'dimension' => array(
+					'description' => esc_html__( 'The dimension to retrieve.', 'wpcloud' ),
+					'type'        => 'string',
+				),
+				'start'     => array(
+					'description' => esc_html__( 'The start time.', 'wpcloud' ),
+					'type'        => 'string',
+					'options'     => array(
+						'default' => null,
+					),
+				),
+				'end'       => array(
+					'description' => esc_html__( 'The end time.', 'wpcloud' ),
+					'type'        => 'string',
+					'options'     => array(
+						'default' => null,
+					),
+				),
+			);
+
+			// Route for site ID in path with metric in path.
 			register_rest_route(
 				$this->namespace,
-				$this->rest_base . '/site/(?<metric>[\w]+)',
+				$this->rest_base . '/site/(?<site_id>[\d]+)/(?<metric>[\w]+)',
 				array(
-					'args'                => array(
-						'site'      => array(
-							'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
-							'type'        => 'integer',
-						),
-						'metric'    => array(
-							'description' => esc_html__( 'The metric to retrieve.', 'wpcloud' ),
-							'type'        => 'string',
-						),
-						'dimension' => array(
-							'description' => esc_html__( 'The dimension to retrieve.', 'wpcloud' ),
-							'type'        => 'string',
-						),
-						'start'     => array(
-							'description' => esc_html__( 'The start time.', 'wpcloud' ),
-							'type'        => 'string',
-							'options'     => array(
-								'default' => null,
-							),
-						),
-						'end'       => array(
-							'description' => esc_html__( 'The end time.', 'wpcloud' ),
-							'type'        => 'string',
-							'options'     => array(
-								'default' => null,
+					'args'                =>
+					array_merge(
+						$common_args,
+						array(
+							'site_id' => array(
+								'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
+								'type'        => 'integer',
 							),
 						),
 					),
@@ -83,7 +91,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		}
 
 		/**
-		 * Get available metrics
+		 * Get available metrics.
 		 *
 		 * @return WP_REST_Response
 		 */
@@ -98,7 +106,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		}
 
 		/**
-		 * Get site metric
+		 * Get site metric.
 		 *
 		 * @param WP_REST_Request $request The request.
 		 *
@@ -106,7 +114,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		 */
 		public function get_site_metric( WP_REST_Request $request ): WP_REST_Response {
 			$params    = $request->get_params();
-			$site_id   = $params['site'];
+			$site_id   = $params['site_id'];
 			$metric    = $params['metric'];
 			$dimension = $params['dimension'] ?? null;
 			$start     = $this->parseTime( $params['start'] ?? null, 'start' );
@@ -145,7 +153,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		}
 
 		/**
-		 * Parse time
+		 * Parse time.
 		 *
 		 * @param string $time The time.
 		 * @param string $position The position.
@@ -165,7 +173,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				'M' => 'months',
 			);
 
-			// check if it's now-{some value} format.
+			// Check if it's now-{some value} format.
 			if ( 0 === strpos( $time, 'now-' ) ) {
 				$time = substr( $time, 3 );
 			}

--- a/plugin/tests/js/components/graph/graph.test.js
+++ b/plugin/tests/js/components/graph/graph.test.js
@@ -28,28 +28,26 @@ describe('Graph Component', () => {
     });
 
     it('renders without crashing', () => {
-        render(<Graph site="test-site" metric="test-metric" />);
+        render(<Graph apiPath="metrics/site/test-site/test-metric" />);
         expect(screen.getByTestId('spinner')).toBeInTheDocument();
     });
 
     it('shows loading state initially', () => {
-        render(<Graph site="test-site" metric="test-metric" />);
+        render(<Graph apiPath="metrics/site/test-site/test-metric" />);
         expect(screen.getByTestId('spinner')).toBeInTheDocument();
     });
 
     it('fetches data with correct parameters', () => {
         const props = {
-            site: 'test-site',
-            metric: 'test-metric',
+            apiPath: 'metrics/site/test-site/test-metric',
             dimension: 'status',
             interval: { start: '2023-01-01', end: '2023-01-31' },
         };
 
         render(<Graph {...props} />);
 
-        expect(stationApi.get).toHaveBeenCalledWith('metrics/site/test-metric', {
+        expect(stationApi.get).toHaveBeenCalledWith('metrics/site/test-site/test-metric', {
             query: {
-                site: 'test-site',
                 start: '2023-01-01',
                 end: '2023-01-31',
                 dimension: 'status',
@@ -68,7 +66,7 @@ describe('Graph Component', () => {
         });
 
         // Render the component
-        const { container } = render(<Graph site="test-site" metric="test-metric" />);
+        const { container } = render(<Graph apiPath="metrics/site/test-site/test-metric" />);
 
         // First, verify the loading state is shown
         expect(screen.getByTestId('spinner')).toBeInTheDocument();
@@ -89,7 +87,7 @@ describe('Graph Component', () => {
         // Reset the mock to ensure we start with a clean slate
         stationApi.get.mockReset();
 
-        const { rerender } = render(<Graph site="test-site" metric="test-metric" refresh={1} />);
+        const { rerender } = render(<Graph apiPath="metrics/site/test-site/test-metric" refresh={1} />);
 
         // First API call
         expect(stationApi.get).toHaveBeenCalledTimes(1);
@@ -98,7 +96,7 @@ describe('Graph Component', () => {
         stationApi.get.mockClear();
 
         // Rerender with a different refresh value
-        rerender(<Graph site="test-site" metric="test-metric" refresh={2} />);
+        rerender(<Graph apiPath="metrics/site/test-site/test-metric" refresh={2} />);
 
         // Should trigger another API call
         expect(stationApi.get).toHaveBeenCalledTimes(1);
@@ -118,7 +116,7 @@ describe('Graph Component', () => {
             });
 
             // Render the component with this graph type
-            const { unmount, container } = render(<Graph site="test-site" metric="test-metric" type={type} />);
+            const { unmount, container } = render(<Graph apiPath="metrics/site/test-site/test-metric" type={type} />);
 
             // Wait for the API call to complete
             await waitFor(() => {
@@ -144,7 +142,7 @@ describe('Graph Component', () => {
         const originalConsoleError = console.error;
         console.error = jest.fn();
 
-        render(<Graph site="test-site" metric="test-metric" />);
+        render(<Graph apiPath="metrics/site/test-site/test-metric" />);
 
         // Wait for the API call to complete
         await waitFor(() => {
@@ -167,7 +165,7 @@ describe('Graph Component', () => {
         // Spy on console.error
         const consoleSpy = jest.spyOn(console, 'error');
 
-        render(<Graph site="test-site" metric="test-metric" />);
+        render(<Graph apiPath="metrics/site/test-site/test-metric" />);
 
         // Wait for the API call to complete
         await waitFor(() => {
@@ -193,7 +191,7 @@ describe('Graph Component', () => {
             }
         };
 
-        const { unmount } = render(<Graph site="test-site" metric="test-metric" />);
+        const { unmount } = render(<Graph apiPath="metrics/site/test-site/test-metric" />);
 
         // Wait for the component to mount and useEffect to run
         await waitFor(() => {


### PR DESCRIPTION
This adds a type attribute to the metrics block which can be one of `site` or `client`

It also updates the React components to :
- make the Graph component indifferent to the metric type by taking the apiPath as a prop
- Have the Metrics component set up the apiPath for the graphs based on the configured type.
- Only look for a site id if the metrics block type is `site`


It also updates the metrics controller to look for the site id in the URL path, i.e `metrics/site/{site_id}/{metric}`

Note: This does not add a route for handling the client metric requests