### PR TITLE
Metrics: Add support for client metrics

### DIFF
--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -59,7 +59,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 					'description' => esc_html__( 'The start time.', 'wpcloud' ),
 					'type'        => 'string',
 					'options'     => array(
-						'default' => '-24 hours',
+						'default' => 'now-24h',
 					),
 				),
 				'end'        => array(

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -166,10 +166,18 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$summarize = $params['summarize'] ?? false;
 
 				$options = array(
-					'filters'    => $params['filters'] ?? null,
 					'top_x'      => $params['top_x'] ?? 20,
 					'resolution' => $params['resolution'] ?? 10,
 				);
+
+				$filters = $params['filters'] ?? null;
+				if ( $filters ) {
+					$filters = json_decode( urldecode( $filters ), true );
+					if ( json_last_error() !== JSON_ERROR_NONE ) {
+						return new WP_REST_Response( esc_html__( 'Invalid filters', 'wpcloud' ), 400 );
+					}
+					$options['filters'] = $filters;
+				}
 
 				$site_id = $params['site_id'] ?? null;
 				if ( $site_id ) {

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -44,24 +44,57 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 			);
 
 			$common_args = array(
-				'metric'    => array(
+				// required args.
+				'metric'     => array(
 					'description' => esc_html__( 'The metric to retrieve.', 'wpcloud' ),
 					'type'        => 'string',
 				),
-				'dimension' => array(
+				'dimension'  => array(
 					'description' => esc_html__( 'The dimension to retrieve.', 'wpcloud' ),
 					'type'        => 'string',
 				),
-				'start'     => array(
+
+				// Default args.
+				'start'      => array(
 					'description' => esc_html__( 'The start time.', 'wpcloud' ),
 					'type'        => 'string',
 					'options'     => array(
-						'default' => null,
+						'default' => '-24 hours',
 					),
 				),
-				'end'       => array(
+				'end'        => array(
 					'description' => esc_html__( 'The end time.', 'wpcloud' ),
 					'type'        => 'string',
+					'options'     => array(
+						'default' => 'now',
+					),
+				),
+				'resolution' => array(
+					'description' => esc_html__( 'The metric resolution.', 'wpcloud' ),
+					'type'        => 'int',
+					'options'     => array(
+						'default' => 10,
+					),
+				),
+				'top_x'      => array(
+					'description' => esc_html__( 'The top X data points.', 'wpcloud' ),
+					'type'        => 'int',
+					'options'     => array(
+						'default' => 20,
+					),
+				),
+				'summarize'  => array(
+					'description' => esc_html__( 'Retrieve a summary vs time based results', 'wpcloud' ),
+					'type'        => 'boolean',
+					'options'     => array(
+						'default' => false,
+					),
+				),
+
+				// Optional args.
+				'filters'    => array(
+					'description' => esc_html__( 'Filters to be applied to the metric query', 'wpcloud' ),
+					'type'        => 'string', // This is an associated array but to make it easier to handle accept json_encoded( array ) aka string.
 					'options'     => array(
 						'default' => null,
 					),
@@ -73,10 +106,9 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$this->namespace,
 				$this->rest_base . '/client/(?<metric>[\w]+)',
 				array(
-					'args'                =>
-					array_merge( $common_args, array( /** client spepcific args */ ) ),
+					'args'                => $common_args,
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_site_metric' ),
+					'callback'            => array( $this, 'get_metric' ),
 					'permission_callback' => array( $this, 'user_access_check' ),
 				)
 			);
@@ -89,6 +121,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 					'args'                =>
 					array_merge(
 						$common_args,
+						// make site_id required.
 						array(
 							'site_id' => array(
 								'description' => esc_html__( 'Unique identifier for the site.', 'wpcloud' ),
@@ -97,7 +130,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 						),
 					),
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_site_metric' ),
+					'callback'            => array( $this, 'get_metric' ),
 					'permission_callback' => array( $this, 'user_access_check' ),
 				)
 			);
@@ -119,56 +152,92 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 		}
 
 		/**
-		 * Get site metric.
+		 * Get metric.
 		 *
 		 * @param WP_REST_Request $request The request.
 		 *
 		 * @return WP_REST_Response
 		 */
-		public function get_site_metric( WP_REST_Request $request ): WP_REST_Response {
-			$params    = $request->get_params();
-			$site_id   = $params['site_id'];
-			$metric    = $params['metric'];
-			$dimension = $params['dimension'] ?? null;
-			$start     = $this->parseTime( $params['start'] ?? null, 'start' );
-			$end       = $this->parseTime( $params['end'] ?? null, 'end' );
+		public function get_metric( WP_REST_Request $request ): WP_REST_Response {
+			try {
+				$params    = $request->get_params();
+				$metric    = $params['metric'];
+				$dimension = $params['dimension'];
+				$summarize = $params['summarize'] ?? false;
 
-			if ( is_wp_error( $start ) || is_wp_error( $end ) ) {
-				return new WP_REST_Response( $start->get_error_message(), 400 );
+				$options = array(
+					'filters'    => $params['filters'] ?? null,
+					'top_x'      => $params['top_x'] ?? 20,
+					'resolution' => $params['resolution'] ?? 10,
+				);
+
+				$site_id = $params['site_id'] ?? null;
+				if ( $site_id ) {
+					$site = new WPCLOUD_Site( $site_id );
+
+					if ( ! $site->post ) {
+						return new WP_REST_Response( esc_html__( 'Site not found', 'wpcloud' ), 404 );
+					}
+					$options['site_id'] = $site_id;
+				}
+
+				$interval = $this->get_interval( $params );
+
+				$view = new WPCLOUD_Metric_Data_View(
+					metric: $metric,
+					dimension: $dimension,
+					interval: $interval,
+					summarize: $summarize,
+					options: $options,
+				);
+				$view = $view->load();
+
+				if ( is_wp_error( $view ) ) {
+					return new WP_REST_Response( $view->get_error_message(), 500 );
+				}
+
+				$result = $view->default();
+
+				if ( is_wp_error( $result ) ) {
+					return new WP_REST_Response( $result->get_error_message(), 500 );
+				}
+
+				$response = array(
+					'meta'   => $result->meta,
+					'series' => $result->series,
+					'data'   => $result->data,
+				);
+				return new WP_REST_Response( $response, 200 );
+			} catch ( Exception $e ) {
+				return new WP_REST_Response( $e->getMessage(), 500 );
+			}
+		}
+
+		/**
+		 * Get the interval.
+		 *
+		 * @param array $params The parameters.
+		 *
+		 * @return array The interval.
+		 * @throws Exception If the time is invalid.
+		 */
+		public function get_interval( array $params ): array {
+			$start = $params['start'] ?? 'now';
+			$end   = $params['end'] ?? 'now-24h';
+			$start = $this->parseTime( $start, 'start' );
+			if ( is_wp_error( $start ) ) {
+				throw new Exception( $start->get_error_message() ); // phpcs:ignore
 			}
 
-			$site = new WPCLOUD_Site( $site_id );
-
-			if ( ! $site->post ) {
-				return new WP_REST_Response( esc_html__( 'Site not found', 'wpcloud' ), 404 );
+			$end = $this->parseTime( $end, 'end' );
+			if ( is_wp_error( $end ) ) {
+				throw new Exception( $end->get_error_message() ); // phpcs:ignore
 			}
 
-			$view = new WPCLOUD_Metric_Data_View(
-				site: $site_id,
-				metric: $metric,
-				dimension: $dimension,
-				start: $start,
-				end: $end,
+			return array(
+				'start' => $start,
+				'end'   => $end,
 			);
-			wpcloud_l( 'call load!!!!!!' );
-			$view = $view->load();
-
-			if ( is_wp_error( $view ) ) {
-				return new WP_REST_Response( $view->get_error_message(), 500 );
-			}
-
-			$result = $view->default();
-
-			if ( is_wp_error( $result ) ) {
-				return new WP_REST_Response( $result->get_error_message(), 500 );
-			}
-
-			$response = array(
-				'meta'   => $result->meta,
-				'series' => $result->series,
-				'data'   => $result->data,
-			);
-			return new WP_REST_Response( $response, 200 );
 		}
 
 		/**

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -68,7 +68,20 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				),
 			);
 
-			// Route for site ID in path with metric in path.
+			// Client metrics.
+			register_rest_route(
+				$this->namespace,
+				$this->rest_base . '/client/(?<metric>[\w]+)',
+				array(
+					'args'                =>
+					array_merge( $common_args, array( /** client spepcific args */ ) ),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_site_metric' ),
+					'permission_callback' => array( $this, 'user_access_check' ),
+				)
+			);
+
+			// Site metrics.
 			register_rest_route(
 				$this->namespace,
 				$this->rest_base . '/site/(?<site_id>[\d]+)/(?<metric>[\w]+)',
@@ -124,25 +137,31 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				return new WP_REST_Response( $start->get_error_message(), 400 );
 			}
 
-			$site = WPCLOUD_Site::get_by_id( $site_id );
+			$site = new WPCLOUD_Site( $site_id );
 
-			if ( ! $site ) {
+			if ( ! $site->post ) {
 				return new WP_REST_Response( esc_html__( 'Site not found', 'wpcloud' ), 404 );
 			}
 
-			$view = WPCLOUD_Metric_Data_View::load(
+			$view = new WPCLOUD_Metric_Data_View(
 				site: $site_id,
 				metric: $metric,
 				dimension: $dimension,
 				start: $start,
 				end: $end,
 			);
+			wpcloud_l( 'call load!!!!!!' );
+			$view = $view->load();
 
 			if ( is_wp_error( $view ) ) {
 				return new WP_REST_Response( $view->get_error_message(), 500 );
 			}
 
 			$result = $view->default();
+
+			if ( is_wp_error( $result ) ) {
+				return new WP_REST_Response( $result->get_error_message(), 500 );
+			}
 
 			$response = array(
 				'meta'   => $result->meta,

--- a/plugin/includes/class-wpcloud-metric-data-view.php
+++ b/plugin/includes/class-wpcloud-metric-data-view.php
@@ -43,32 +43,25 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 	public $dimensions;
 
 	/**
-	 * Generate the view.
+	 * Load data.
 	 *
-	 * @param int    $site      The site.
-	 * @param string $metric    The metric.
-	 * @param string $dimension The dimension.
-	 * @param int    $start     The start.
-	 * @param int    $end       The end.
-	 *
-	 * @return WP_Error|WPCLOUD_Metric_Data
+	 * @return WP_Error|WPCLOUD_Metric_Data_View
 	 */
-	public static function load( int $site, string $metric, string $dimension, int $start, int $end ): WP_Error|WPCLOUD_Metric_Data_View {
-		// validate the metric and dimension.
-		$view = new self( $site, $metric, $dimension, $start, $end );
-		if ( ! array_key_exists( $view->metric, $view->get_available_metrics() ) ) {
+	public function load(): WP_Error|WPCLOUD_Metric_Data_View {
+		// Validate the metric and dimension.
+		if ( ! array_key_exists( $this->metric, $this->get_available_metrics() ) ) {
 			return new WP_Error( 'invalid_metric', 'Invalid metric', array( 'status' => 400 ) );
 		}
 
-		if ( ! array_key_exists( $view->dimension, $view->get_available_dimensions() ) ) {
+		if ( ! array_key_exists( $this->dimension, $this->get_available_dimensions() ) ) {
 			return new WP_Error( 'invalid_dimension', 'Invalid dimension', array( 'status' => 400 ) );
 		}
 
-		$view->fetch();
-		if ( is_wp_error( $view->result ) ) {
-			return $view->result;
+		$this->fetch();
+		if ( is_wp_error( $this->result ) ) {
+			return $this->result;
 		}
-		return $view;
+		return $this;
 	}
 
 	/**
@@ -78,10 +71,6 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 	 */
 	public function default(): WP_Error|WPCLOUD_Metric_Data_View {
 		$this->set_dimensions();
-		if ( empty( $this->dimensions ) ) {
-			return new WP_Error( 'no_dimensions', 'No dimensions found', array( 'status' => 400 ) );
-		}
-
 		$this->set_series();
 		$this->set_data();
 		return $this;
@@ -141,7 +130,7 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 		}
 
 		foreach ( $this->periods as $row ) {
-			$x = $row['timestamp'];
+			$x = $row['timestamp'] ?? '';
 			if ( empty( $x ) ) {
 				continue;
 			}

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -19,7 +19,7 @@ class WPCloud_Metrics {
 	 *
 	 * @var int
 	 */
-	protected int $site;
+	protected ?int $site;
 
 	/**
 	 * The metric.
@@ -33,7 +33,7 @@ class WPCloud_Metrics {
 	 *
 	 * @var string
 	 */
-	protected string $dimension;
+	protected ?string $dimension;
 
 	/**
 	 * The start.
@@ -83,15 +83,15 @@ class WPCloud_Metrics {
 	/**
 	 * Constructor.
 	 *
-	 * @param int      $site     The site.
 	 * @param string   $metric   The metric.
 	 * @param string   $dimension The dimension.
 	 * @param int|null $start    The start.
 	 * @param int|null $end      The end.
+	 * @param int      $site     The site.
 	 *
 	 * @throws Exception If the type is invalid.
 	 */
-	public function __construct( int $site, string $metric, string $dimension, ?int $start = null, ?int $end = null ) {
+	public function __construct( string $metric, ?string $dimension, ?int $start = null, ?int $end = null, ?int $site = null ) {
 		$this->site      = $site;
 		$this->metric    = $metric;
 		$this->dimension = $dimension;
@@ -156,7 +156,6 @@ class WPCloud_Metrics {
 		return $this->get_data( $options );
 	}
 
-
 	/**
 	 * Get the data.
 	 *
@@ -165,21 +164,41 @@ class WPCloud_Metrics {
 	 * @return WP_Error|array The data
 	 */
 	public function fetch( array $options = array() ): WP_Error|WPCloud_Metrics {
-		$options = array_merge(
+		$options   = array_merge(
 			array(
 				'metric'    => $this->metric,
 				'dimension' => $this->dimension,
-				'summarize' => false,
+				'start'     => $this->start,
+				'end'       => $this->end,
 			),
 			$options
 		);
+		$summarize = $options['summarize'] ?? false;
+		unset( $options['summarize'] );
 
-		$this->result = wpcloud_client_site_metrics( $this->site, $this->start, $this->end, $options );
-		if ( is_wp_error( $this->result ) ) {
-			return $this->result;
+		$wpcloud_client = new WPCloud_API_Client( use_cache: false );
+		if ( $this->site ) {
+			$wpcloud_client->set_site_id( $this->site );
+			$path = 'metrics/site/:site_id';
+		} else {
+			$path = 'metrics/client/:client';
 		}
-		$this->meta    = (array) $this->result->_meta;
-		$this->periods = json_decode( wp_json_encode( $this->result->periods ), true );
+		if ( $summarize ) {
+			$path .= '/summarize';
+		}
+
+		$result = $wpcloud_client->post( $path, $options );
+		wpcloud_l( 'metrics results', $result->data );
+
+		if ( ! $result->is_ok() ) {
+			$this->result = $result->error;
+			return $result->error;
+		}
+
+		$this->result  = $result;
+		$this->meta    = (array) $result->_meta;
+		$this->periods = json_decode( wp_json_encode( $result->periods ), true );
+
 		return $this;
 	}
 

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -15,13 +15,6 @@ require_once __DIR__ . '/wpcloud-client.php';
 class WPCloud_Metrics {
 
 	/**
-	 * The site.
-	 *
-	 * @var int
-	 */
-	protected ?int $site;
-
-	/**
 	 * The metric.
 	 *
 	 * @var string
@@ -33,7 +26,14 @@ class WPCloud_Metrics {
 	 *
 	 * @var string
 	 */
-	protected ?string $dimension;
+	protected string $dimension;
+
+	/**
+	 * The metric options.
+	 *
+	 * @var array
+	 */
+	protected array $options;
 
 	/**
 	 * The start.
@@ -48,6 +48,13 @@ class WPCloud_Metrics {
 	 * @var int|null
 	 */
 	protected ?int $end;
+
+	/**
+	 * Summarize the data.
+	 *
+	 * @var bool
+	 */
+	protected bool $summarize;
 
 	/**
 	 * The result.
@@ -83,77 +90,22 @@ class WPCloud_Metrics {
 	/**
 	 * Constructor.
 	 *
-	 * @param string   $metric   The metric.
-	 * @param string   $dimension The dimension.
-	 * @param int|null $start    The start.
-	 * @param int|null $end      The end.
-	 * @param int      $site     The site.
+	 * @param string $metric   The metric.
+	 * @param string $dimension The dimension.
+	 * @param array  $interval The interval.
+	 * @param bool   $summarize Whether to summarize the data.
+	 * @param array  $options  The metric options.
 	 *
 	 * @throws Exception If the type is invalid.
 	 */
-	public function __construct( string $metric, ?string $dimension, ?int $start = null, ?int $end = null, ?int $site = null ) {
-		$this->site      = $site;
+	public function __construct( string $metric, string $dimension, array $interval, bool $summarize = false, array $options = array() ) {
+
 		$this->metric    = $metric;
 		$this->dimension = $dimension;
-		$this->start     = $start ?? strtotime( '-24 hours' );
-		$this->end       = $end ?? time();
-	}
-
-	/**
-	 * Get the requests.
-	 *
-	 * @param string $dimension The dimension.
-	 * @param bool   $summarize Summarize the data.
-	 *
-	 * @return WP_Error|array The data
-	 */
-	public function requests( ?string $dimension = null, bool $summarize = false ): WP_Error|array {
-		$options = array(
-			'metric'    => 'requests_persec',
-			'dimension' => $dimension,
-			'summarize' => $summarize,
-		);
-
-		return $this->get_data( $options );
-	}
-
-	/**
-	 * Get the response bytes.
-	 *
-	 * @param string $dimension The dimension.
-	 * @param bool   $average   Average the data.
-	 * @param bool   $summarize Summarize the data.
-	 *
-	 * @return WP_Error|array The data
-	 */
-	public function response_bytes( ?string $dimension = null, bool $average = false, bool $summarize = false ): array {
-		$metric = $average ? 'response_bytes_average' : 'response_bytes_persec';
-
-		$options = array(
-			'metric'    => $metric,
-			'dimension' => $dimension,
-			'summarize' => $summarize,
-		);
-
-		return $this->get_data( $options );
-	}
-
-	/**
-	 * Get the response time.
-	 *
-	 * @param string $dimension The dimension.
-	 * @param bool   $summarize Summarize the data.
-	 *
-	 * @return WP_Error|array The data
-	 */
-	public function response_time( ?string $dimension = null, bool $summarize = false ): array {
-		$options = array(
-			'metric'    => 'response_time_average',
-			'dimension' => $dimension,
-			'summarize' => $summarize,
-		);
-
-		return $this->get_data( $options );
+		$this->start     = $interval['start'];
+		$this->end       = $interval['end'];
+		$this->options   = $options;
+		$this->summarize = $summarize;
 	}
 
 	/**
@@ -164,26 +116,28 @@ class WPCloud_Metrics {
 	 * @return WP_Error|array The data
 	 */
 	public function fetch( array $options = array() ): WP_Error|WPCloud_Metrics {
-		$options   = array_merge(
+		$options = array_merge(
 			array(
 				'metric'    => $this->metric,
 				'dimension' => $this->dimension,
 				'start'     => $this->start,
 				'end'       => $this->end,
 			),
+			$this->options,
 			$options
 		);
-		$summarize = $options['summarize'] ?? false;
-		unset( $options['summarize'] );
 
-		$wpcloud_client = new WPCloud_API_Client( use_cache: false );
-		if ( $this->site ) {
-			$wpcloud_client->set_site_id( $this->site );
+		$site_id = $options['site_id'] ?? 0;
+		unset( $options['site_id'] );
+
+		$wpcloud_client = new WPCloud_API_Client( site_id: $site_id, use_cache: false );
+		if ( $site_id ) {
 			$path = 'metrics/site/:site_id';
 		} else {
 			$path = 'metrics/client/:client';
 		}
-		if ( $summarize ) {
+
+		if ( $this->summarize ) {
 			$path .= '/summarize';
 		}
 

--- a/plugin/includes/class-wpcloud-site.php
+++ b/plugin/includes/class-wpcloud-site.php
@@ -22,20 +22,28 @@ class WPCLOUD_Site {
 	 *
 	 * @var WP_Post
 	 */
-	protected $post;
+	protected $post = null;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param WP_Post $post The post object for the site.
+	 * @param WP_Post|string|int $post_or_id The post object or id for the site.
 	 * @return void
 	 */
-	public function __construct( $post = null ) {
-		if ( ! $post ) {
+	public function __construct( $post_or_id = null ) {
+		if ( $post_or_id instanceof WP_Post ) {
+			$post = $post_or_id;
+		} elseif ( is_numeric( $post_or_id ) ) {
+			// Try to find the post by atomic site id.
+			$post = self::get_by_id( $post_or_id );
+			if ( ! $post ) {
+				$post = get_post( $post_or_id );
+			}
+		} else {
 			$post = get_post();
 		}
 
-		if ( 'wpcloud_site' === $post->post_type ) {
+		if ( ( $post instanceof WP_Post ) && 'wpcloud_site' === $post->post_type ) {
 			$this->post = $post;
 		}
 	}
@@ -47,6 +55,9 @@ class WPCLOUD_Site {
 	 * @return mixed
 	 */
 	public function __get( string $name ): mixed {
+		if ( 'post' === $name ) {
+			return $this->post;
+		}
 		if ( ! $this->post ) {
 			return null;
 		}
@@ -188,6 +199,15 @@ class WPCLOUD_Site {
 		return $site[0];
 	}
 
+	/**
+	 * Get the site post.
+	 *
+	 * @param int $wpcloud_site_id The site ID.
+	 * @return null|WP_Post
+	 */
+	public function get_site_post( ?int $wpcloud_site_id ): null|WP_Post {
+		return self::get_by_id( $wpcloud_site_id );
+	}
 
 	/**
 	 * Create a new wpcloud_site custom post type.

--- a/plugin/tests/test-wpcloud-metrics-controller.php
+++ b/plugin/tests/test-wpcloud-metrics-controller.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Class WPCLOUD_Metrics_ControllerTest
+ *
+ * @package wpcloud-station
+ */
+
+/**
+ * Test case for the WPCLOUD_Metrics_Controller class.
+ */
+class WPCLOUD_Metrics_ControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * The controller instance.
+	 *
+	 * @var WPCLOUD_Metrics_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Test site ID.
+	 *
+	 * @var int
+	 */
+	private $site_id;
+
+	/**
+	 * Test post for the site.
+	 *
+	 * @var WP_Post
+	 */
+	private $post;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Create a test user for the site.
+		$user_id = $this->factory->user->create(
+			array(
+				'user_login' => 'testuser',
+				'user_email' => 'testuser@example.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		// Create a test post for the site.
+		$post_id    = $this->factory->post->create(
+			array(
+				'post_title'  => 'Test Site',
+				'post_type'   => 'wpcloud_site',
+				'post_status' => 'publish',
+				'post_author' => $user_id,
+			)
+		);
+		$this->post = get_post( $post_id );
+
+		// Add site ID meta.
+		$this->site_id = 123;
+		update_post_meta( $post_id, 'wpcloud_site_id', $this->site_id );
+
+		// Create controller instance.
+		$this->controller = new WPCLOUD_Metrics_Controller();
+
+		// Define the capability constant if not already defined.
+		if ( ! defined( 'WPCLOUD_CAN_MANAGE_SITES' ) ) {
+			define( 'WPCLOUD_CAN_MANAGE_SITES', 'manage_options' );
+		}
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		\Mockery::close();
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		wp_delete_post( $this->post->ID, true );
+		parent::tear_down();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		\Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test parseTime method with valid time strings.
+	 */
+	public function test_parseTime_valid_strings() {
+		// Test with null.
+		$this->assertNull( $this->controller->parseTime( null, 'start' ) );
+
+		// Test with 'now'.
+		$now = time();
+		$this->assertEqualsWithDelta( $now, $this->controller->parseTime( 'now', 'start' ), 2 );
+
+		// Test with 'now-1h'.
+		$one_hour_ago = strtotime( '-1 hour' );
+		$this->assertEqualsWithDelta( $one_hour_ago, $this->controller->parseTime( 'now-1h', 'start' ), 2 );
+
+		// Test with '1h' (should be interpreted as now-1h).
+		$this->assertEqualsWithDelta( $one_hour_ago, $this->controller->parseTime( '1h', 'start' ), 2 );
+
+		// Test with other units.
+		$this->assertEqualsWithDelta( strtotime( '-30 seconds' ), $this->controller->parseTime( '30s', 'start' ), 2 );
+		$this->assertEqualsWithDelta( strtotime( '-15 minutes' ), $this->controller->parseTime( '15m', 'start' ), 2 );
+		$this->assertEqualsWithDelta( strtotime( '-2 days' ), $this->controller->parseTime( '2d', 'start' ), 2 );
+		$this->assertEqualsWithDelta( strtotime( '-3 months' ), $this->controller->parseTime( '3M', 'start' ), 2 );
+
+		// Test with absolute time string.
+		$this->assertEqualsWithDelta( strtotime( '2023-01-01' ), $this->controller->parseTime( '2023-01-01', 'start' ), 2 );
+	}
+
+	/**
+	 * Test parseTime method with invalid time strings.
+	 */
+	public function test_parseTime_invalid_strings() {
+		// Test with invalid time string.
+		$result = $this->controller->parseTime( 'invalid-time', 'start' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertEquals( 'Invalid start time', $result->get_error_message() );
+
+		// Test with future time.
+		$result = $this->controller->parseTime( '2050-01-01', 'end' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_invalid_param', $result->get_error_code() );
+		$this->assertEquals( 'Invalid end time', $result->get_error_message() );
+	}
+
+	/**
+	 * Test user_access_check method with authorized user.
+	 */
+	public function test_user_access_check_authorized() {
+		// Create an admin user.
+		$user_id = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Call the method.
+		$result = $this->controller->user_access_check();
+
+		// Check the result.
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test user_access_check method with unauthorized user.
+	 */
+	public function test_user_access_check_unauthorized() {
+		// Create a subscriber user.
+		$user_id = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Call the method.
+		$result = $this->controller->user_access_check();
+
+		// Check the result.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+		$this->assertEquals( 'Unauthorized request', $result->get_error_message() );
+	}
+
+	/**
+	 * Test user_access_check method with no user.
+	 */
+	public function test_user_access_check_no_user() {
+		// Set current user to 0 (no user).
+		wp_set_current_user( 0 );
+
+		// Call the method.
+		$result = $this->controller->user_access_check();
+
+		// Check the result.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
+		$this->assertEquals( 'Unauthorized request', $result->get_error_message() );
+	}
+}

--- a/plugin/tests/test-wpcloud-site.php
+++ b/plugin/tests/test-wpcloud-site.php
@@ -267,18 +267,18 @@ class WPCloud_SiteTest extends WP_UnitTestCase {
 		$about_a_gig = 1073741824;
 		Mock_Helper::mock_api_requests(
 			array(
-				'site-meta/123/space_used/get'      => (object) array(
+				'site-meta/123/space_used/get'        => (object) array(
 					'data' => $about_a_gig,
 				),
-				'site-meta/123/db_file_size/get'    => (object) array(
+				'site-meta/123/db_file_size/get'      => (object) array(
 					'data' => $about_a_gig,
 				),
 				// Check for empty values.
-				'site-meta/123/space_quota/get'     => (object) array(
+				'site-meta/123/space_quota/get'       => (object) array(
 					'data' => '',
 				),
 				// Test other site meta.
-				'site-meta/123/burst_php_conns/get' => (object) array(
+				'site-meta/123/default_php_conns/get' => (object) array(
 					'data' => '6',
 				),
 			)
@@ -291,8 +291,8 @@ class WPCloud_SiteTest extends WP_UnitTestCase {
 		$this->assertEquals( '0 B', $no_value );
 
 		// Test that raw metadata is returned correctly.
-		$burst_php_conns = WPCloud_Site::get_detail( $this->post, 'burst_php_conns' );
-		$this->assertEquals( '6', $burst_php_conns );
+		$default_php_conns = WPCloud_Site::get_detail( $this->post, 'default_php_conns' );
+		$this->assertEquals( '6', $default_php_conns );
 
 		// Check edge cache.
 		Mock_Helper::mock_api_request(


### PR DESCRIPTION
This updates the json api to allow requesting client metrics.
The endpoint for client metrics is `/metrics/client`, client name is scoped to the Station client
It also adds new options for requesting metric data and add simple tests for metrics controller.