### PR TITLE
Metric: Add more graph attributes

### DIFF
--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -64,7 +64,10 @@
 				86400
 			]
 		},
-
+		"summarize": {
+			"type": "boolean",
+			"default": false
+		},
 		"type": {
 			"type": "string",
 			"default": "line"

--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -68,6 +68,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"topX": {
+			"type": "number",
+			"default": 20
+		},
 		"type": {
 			"type": "string",
 			"default": "line"

--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -38,6 +38,33 @@
 			"type" : "string",
 			"default" : "https_status"
 		},
+		"resolution" : {
+			"type" : "number",
+			"default" : 10,
+			"enum": [
+				10,
+				20,
+				30,
+				60,
+				120,
+				180,
+				240,
+				300,
+				600,
+				900,
+				1200,
+				1800,
+				3600,
+				7200,
+				10800,
+				14400,
+				21600,
+				28800,
+				43200,
+				86400
+			]
+		},
+
 		"type": {
 			"type": "string",
 			"default": "line"

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
 
-export default function Graph({ metric, dimension, resolution, summarize, type, title, interval, refresh, showLegend, styles = {}, className = '', minWidth='500px' } ) {
+export default function Graph({ metric, dimension, resolution, summarize, topX, type, title, interval, refresh, showLegend, styles = {}, className = '', minWidth='500px' } ) {
 
 	const { apiPath } = useApiContext();
 	const { start, end } = interval || {};
@@ -49,6 +49,7 @@ export default function Graph({ metric, dimension, resolution, summarize, type, 
 						dimension,
 						resolution,
 						summarize,
+						top_x: topX,
 					}, parse: true, signal
 				});
 				setData(data);

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,8 +20,7 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
 
-
-export default function Graph({ metric, dimension, type, title, interval, refresh, showLegend, styles = {}, className = '', minWidth='500px' } ) {
+export default function Graph({ metric, dimension, resolution, summarize, type, title, interval, refresh, showLegend, styles = {}, className = '', minWidth='500px' } ) {
 
 	const { apiPath } = useApiContext();
 	const { start, end } = interval || {};
@@ -47,7 +46,9 @@ export default function Graph({ metric, dimension, type, title, interval, refres
 					query: {
 						start,
 						end,
-						dimension
+						dimension,
+						resolution,
+						summarize,
 					}, parse: true, signal
 				});
 				setData(data);
@@ -63,7 +64,7 @@ export default function Graph({ metric, dimension, type, title, interval, refres
 
 		fetchData();
 		return () => controller.abort();
-	}, [ apiPath,start, end, refresh ] );
+	}, [ apiPath, start, end, refresh ] );
 
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type });

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -14,6 +14,7 @@ import {
 	TextControl,
 	ToggleControl,
 	SelectControl,
+	__experimentalNumberControl as NumberControl,
 	Spinner
 } from '@wordpress/components';
 
@@ -25,7 +26,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { metric, dimension, resolution, type, title, showLegend, minWidth, summarize } = attributes;
+	const { metric, dimension, resolution, topX, type, title, showLegend, minWidth, summarize } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -45,7 +46,29 @@ export default function Edit( { attributes, setAttributes } ) {
 	const controls = (
 		<InspectorControls>
 			<PanelBody title={__('graph Settings')}>
-
+				<SelectControl
+					label={ __( 'Type' ) }
+					value={ type }
+					options={ [
+						{ label: __( 'Area' ), value: 'area' },
+						{ label: __( 'Line' ), value: 'line' },
+						{ label: __('Bar'), value: 'bar' },
+						{ label: __('Stacked Bar'), value: 'stacked-bar' },
+					] }
+					onChange={ update('type') }
+				/>
+				<TextControl
+					label={ __( 'Title' ) }
+					value={ title }
+					onChange={ update('title') }
+				/>
+				<ToggleControl
+					label={ __( 'Show Legend' ) }
+					checked={ showLegend }
+					onChange={ update('showLegend') }
+				/>
+			</PanelBody>
+			<PanelBody title={__('Graph Data')}>
 				{loading && <Spinner />}
 				{!loading && (
 					<>
@@ -88,34 +111,26 @@ export default function Edit( { attributes, setAttributes } ) {
 							]}
 							onChange={update('resolution')}
 						/>
+						<NumberControl
+							label={__('Top X')}
+							value={topX}
+							onChange={update('topX')}
+							min={1}
+							max={100}
+							step={1}
+							isShiftStepEnabled={true}
+							shiftStep={5}
+						/>
+
 						<ToggleControl
 							label={__('Summarize')}
 							checked={summarize}
 							onChange={update('summarize')}
 						/>
 					</>)}
-				<SelectControl
-					label={ __( 'Type' ) }
-					value={ type }
-					options={ [
-						{ label: __( 'Area' ), value: 'area' },
-						{ label: __( 'Line' ), value: 'line' },
-						{ label: __('Bar'), value: 'bar' },
-						{ label: __('Stacked Bar'), value: 'stacked-bar' },
-					] }
-					onChange={ update('type') }
-				/>
-				<TextControl
-					label={ __( 'Title' ) }
-					value={ title }
-					onChange={ update('title') }
-				/>
-				<ToggleControl
-					label={ __( 'Show Legend' ) }
-					checked={ showLegend }
-					onChange={ update('showLegend') }
-				/>
+
 			</PanelBody>
+
 			<PanelBody title={__('Graph Size')}>
 				<TextControl
 					label={ __( 'Minimum Width' ) }

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -116,10 +116,10 @@ export default function Edit( { attributes, setAttributes } ) {
 							value={topX}
 							onChange={update('topX')}
 							min={1}
-							max={100}
+							max={20}
 							step={1}
 							isShiftStepEnabled={true}
-							shiftStep={5}
+							shiftStep={1}
 						/>
 
 						<ToggleControl

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -25,7 +25,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { metric, dimension, resolution, type, title, showLegend, minWidth } = attributes;
+	const { metric, dimension, resolution, type, title, showLegend, minWidth, summarize } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -87,6 +87,11 @@ export default function Edit( { attributes, setAttributes } ) {
 								{ label: __('1 Day'), value: '86400' },
 							]}
 							onChange={update('resolution')}
+						/>
+						<ToggleControl
+							label={__('Summarize')}
+							checked={summarize}
+							onChange={update('summarize')}
 						/>
 					</>)}
 				<SelectControl

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -45,7 +45,7 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	const controls = (
 		<InspectorControls>
-			<PanelBody title={__('graph Settings')}>
+			<PanelBody title={__('Graph Settings')}>
 				<SelectControl
 					label={ __( 'Type' ) }
 					value={ type }

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -25,7 +25,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { metric, dimension, type, title, showLegend, minWidth } = attributes;
+	const { metric, dimension, resolution, type, title, showLegend, minWidth } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -60,6 +60,33 @@ export default function Edit( { attributes, setAttributes } ) {
 							value={dimension}
 							options={Object.keys(dimensions).map((key) => ({ label: dimensions[key], value: key })) }
 							onChange={update('dimension')}
+						/>
+						<SelectControl
+							label={__('Resolution')}
+							value={resolution}
+							options={[
+								{ label: __('10 Seconds'), value: '10' },
+								{ label: __('20 Seconds'), value: '20' },
+								{ label: __('30 Seconds'), value: '30' },
+								{ label: __('1 Minute'), value: '60' },
+								{ label: __('2 Minutes'), value: '120' },
+								{ label: __('3 Minutes'), value: '180' },
+								{ label: __('4 Minutes'), value: '240' },
+								{ label: __('5 Minutes'), value: '300' },
+								{ label: __('10 Minutes'), value: '600' },
+								{ label: __('15 Minutes'), value: '900' },
+								{ label: __('20 Minutes'), value: '1200' },
+								{ label: __('30 Minutes'), value: '1800' },
+								{ label: __('1 Hour'), value: '3600' },
+								{ label: __('2 Hours'), value: '7200' },
+								{ label: __('3 Hours'), value: '10800' },
+								{ label: __('4 Hours'), value: '14400' },
+								{ label: __('6 Hours'), value: '21600' },
+								{ label: __('8 Hours'), value: '28800' },
+								{ label: __('12 Hours'), value: '43200' },
+								{ label: __('1 Day'), value: '86400' },
+							]}
+							onChange={update('resolution')}
 						/>
 					</>)}
 				<SelectControl


### PR DESCRIPTION
Fixes: #299 

Adds:
- summarize (bool)
- resoution (10sec-> 1hour, default 10sec )
- topX ( 1 -> 20, default 20)

Also updates control panel sections.

<img width="283" alt="Screenshot 2025-04-10 at 12 44 40 AM" src="https://github.com/user-attachments/assets/5d762b0d-68d7-4b0d-a1d6-b479061b0df0" />
