### PR TITLE
Metrics: Add graph orieintation for bar graphs

### DIFF
--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -76,6 +76,10 @@
 			"type": "string",
 			"default": "line"
 		},
+		"orientation": {
+			"type": "string",
+			"default": "vertical"
+		},
 		"title" : {
 			"type" : "string",
 			"default" : "Status Codes"

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -20,7 +20,31 @@ import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
 
-export default function Graph({ metric, dimension, resolution, summarize, topX, type, title, interval, refresh, showLegend, styles = {}, className = '', minWidth='500px' } ) {
+export default function Graph( props ) {
+
+	const {
+		// Core props.
+		title,
+		type,
+		showLegend,
+
+		// Styling props.
+		styles = {},
+		className = '',
+		minWidth = '500px',
+
+		// Static metric props.
+		metric,
+		dimension,
+		resolution,
+		summarize,
+		topX,
+		orientation,
+
+		// Dynamic metric props.
+		interval, refresh
+
+	} = props;
 
 	const { apiPath } = useApiContext();
 	const { start, end } = interval || {};
@@ -68,7 +92,7 @@ export default function Graph({ metric, dimension, resolution, summarize, topX, 
 	}, [ apiPath, start, end, refresh ] );
 
 
-	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type });
+	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type, orientation });
 	const hasData = data.length > 0 && data[0].length > 0;
 
 	// Force loading to false after data is loaded

--- a/plugin/blocks/src/components/graph/components/lib/options.js
+++ b/plugin/blocks/src/components/graph/components/lib/options.js
@@ -105,14 +105,14 @@ export function stackedOptions({ series:s, data:d, useStatus, seriesOptions, dir
 	const plugins = [seriesBarsPlugin({ stacked: true, dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultBarOptions({ bands, data, plugins, series, ...options });
+	return withDefaultBarOptions({ bands, data, plugins, series, ori, ...options });
 }
 
 export function barOptions({ series: s, useStatus, seriesOptions, dir, ori, ...options }) {
 	const plugins = [seriesBarsPlugin({ dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultBarOptions({ series, plugins, ...options });
+	return withDefaultBarOptions({ series, plugins, ori, ...options });
 }
 
 export function lineOptions({ series, useStatus, seriesOptions, ...options }) {

--- a/plugin/blocks/src/components/graph/components/lib/options.js
+++ b/plugin/blocks/src/components/graph/components/lib/options.js
@@ -37,13 +37,45 @@ function buildSeries(series, options = {}) {
 	return [series[0], ...ySeries];
 }
 
-function withDefaultOptions({ ori = 0, ...opts }) {
+function withDefaultOptions(opts) {
+	return {
+		padding: [null, 0, null, 0],
+		ori: 0,
+		axes: [{}, {}],
+		legend: { live: false, markers: { width: 2 } },
+		scales: {
+			y: {
+				range: [0, null],
+				ori: 1,
+			}
+		},
+		...opts
+	};
+}
+
+function withDefaultBarOptions({ ori = 0, ...opts }) {
 	// if horizontal ( ori === 1 ) place the y axis marks on the top (0)
 	// if vertical ( ori === 0 ) place the y axis marks on the right (3)
 	const side = ori === 0 ? 3 : 0;
 	// if horizontal ( ori === 1 ) set the y axis to read from top to bottom (1)
 	// if vertical ( ori === 0 ) set the y axis to read from left to right (0)
 	const yOri = ori === 0 ? 1 : 0;
+	const newOpts =  withDefaultOptions({
+		...opts,
+		ori,
+		axes: [{}, {
+			side
+		}],
+		scales: {
+			y: {
+				range: [0, null],
+				ori: yOri,
+			}
+		},
+	});
+	console.log('newOpts', newOpts);
+	return newOpts;
+	/*
 	return {
 		padding: [null, 0, null, 0],
 		ori,
@@ -59,6 +91,7 @@ function withDefaultOptions({ ori = 0, ...opts }) {
 		},
 		...opts
 	};
+	*/
 }
 
 function scaleFunc(options) {
@@ -72,27 +105,30 @@ export function stackedOptions({ series:s, data:d, useStatus, seriesOptions, dir
 	const plugins = [seriesBarsPlugin({ stacked: true, dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultOptions({ bands, data, plugins, series, ori, ...options });
+	return withDefaultBarOptions({ bands, data, plugins, series, ...options });
 }
 
 export function barOptions({ series: s, useStatus, seriesOptions, dir, ori, ...options }) {
-	console.log('barOptions', dir, ori);
 	const plugins = [seriesBarsPlugin({ dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultOptions({ series, plugins, ori, ...options });
+	return withDefaultBarOptions({ series, plugins, ...options });
 }
 
 export function lineOptions({ series, useStatus, seriesOptions, ...options }) {
+	// @TODO: Before allowing vertical line graphs, we need to figure out how to rotate the data.
+	const ori = 0;
 	const strokeScale = scaleFunc({ series, useStatus, seriesOptions });
-	return withDefaultOptions({ series: buildSeries(series, { strokeScale, ...seriesOptions }), ...options });
+	return withDefaultOptions({ series: buildSeries(series, { strokeScale, ...seriesOptions }), ori, ...options });
 }
 
 export function areaOptions({ series, useStatus, seriesOptions, ...options }) {
+	// @TODO: Before allowing vertical area graphs, we need to figure out how to rotate the data.
+	const ori = 0;
 	const scaleOptions = {series, useStatus, seriesOptions};
 	const fillScale = scaleFunc(scaleOptions);
 	const strokeScale = scaleFunc(scaleOptions);
-	return withDefaultOptions({ series: buildSeries(series, { fillScale, strokeScale, ...seriesOptions }), ...options });
+	return withDefaultOptions({ series: buildSeries(series, { fillScale, strokeScale, ...seriesOptions }), ori, ...options });
 }
 
 export function defaultOptions({ series, useStatus, seriesOptions, ...rest }) {

--- a/plugin/blocks/src/components/graph/components/lib/options.js
+++ b/plugin/blocks/src/components/graph/components/lib/options.js
@@ -37,19 +37,29 @@ function buildSeries(series, options = {}) {
 	return [series[0], ...ySeries];
 }
 
-function withDefaultOptions(opts) {
+function withDefaultOptions({ ori = 0, ...opts }) {
+	// if horizontal ( ori === 1 ) place the y axis marks on the top (0)
+	// if vertical ( ori === 0 ) place the y axis marks on the right (3)
+	const side = ori === 0 ? 3 : 0;
+	// if horizontal ( ori === 1 ) set the y axis to read from top to bottom (1)
+	// if vertical ( ori === 0 ) set the y axis to read from left to right (0)
+	const yOri = ori === 0 ? 1 : 0;
 	return {
 		padding: [null, 0, null, 0],
-		ori: 0,
-		axes: [{}, {}],
+		ori,
+		axes: [{}, {
+			side
+		}],
 		legend: { live: false, markers: { width: 2 } },
 		scales: {
-			y: { range: [0, null], ori: 1 }
+			y: {
+				range: [0, null],
+				ori: yOri,
+			}
 		},
 		...opts
 	};
 }
-
 
 function scaleFunc(options) {
  	const { series, useStatus = false, seriesOptions = {} } = options;
@@ -57,19 +67,20 @@ function scaleFunc(options) {
 	return useStatus ? statusScale({seriesOptions}) : indexScale({ domainEnd, ...seriesOptions } );
 }
 
-export function stackedOptions({ series:s, data:d, useStatus, seriesOptions, ...options}) {
-	const { bands, data  } = stack(d);
-	const plugins = [seriesBarsPlugin({ stacked: true })];
+export function stackedOptions({ series:s, data:d, useStatus, seriesOptions, dir, ori, ...options}) {
+	const { bands, data } = stack(d);
+	const plugins = [seriesBarsPlugin({ stacked: true, dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultOptions({ bands, data, plugins, series, ...options });
+	return withDefaultOptions({ bands, data, plugins, series, ori, ...options });
 }
 
-export function barOptions({ series:s, useStatus, seriesOptions, ...options }) {
-	const plugins = [seriesBarsPlugin()];
+export function barOptions({ series: s, useStatus, seriesOptions, dir, ori, ...options }) {
+	console.log('barOptions', dir, ori);
+	const plugins = [seriesBarsPlugin({ dir, ori })];
 	const fillScale = scaleFunc({ series: s, useStatus, seriesOptions });
 	const series = buildSeries(s, { fillScale, ...seriesOptions });
-	return withDefaultOptions({ series, plugins, ...options });
+	return withDefaultOptions({ series, plugins, ori, ...options });
 }
 
 export function lineOptions({ series, useStatus, seriesOptions, ...options }) {

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import croma from 'chroma-js';
 import { stackedOptions, defaultOptions, barOptions, lineOptions, areaOptions } from './options';
 
 // Remove this amount from the container height to fit the graph legend.
@@ -7,7 +6,6 @@ const fitGraphHeight = 75;
 const fitGraphWidth = 20;
 
 export default (options) => {
-
 	const {
 		title,
 		series,
@@ -16,6 +14,7 @@ export default (options) => {
 		containerRef,
 		showLegend,
 		type,
+		orientation,
 	} = options;
 
 	const [width, setWidth] = useState(808);
@@ -48,8 +47,12 @@ export default (options) => {
 		height,
 		series,
 		data,
-		useStatus: meta.dimension?.includes('status')
+		useStatus: meta.dimension?.includes('status'),
+		ori: 'vertical' === orientation ? 0 : 1,
+		dir: 'vertical' === orientation ? 1 : -1,
 	};
+
+	console.log('graphOptions', orientation, graphOptions);
 
 	if (!showLegend) {
 		graphOptions.legend = { live: false };
@@ -63,7 +66,6 @@ export default (options) => {
 			return stackedOptions({...graphOptions, seriesOptions });
 
 		case 'bar':
-			seriesOptions = { fillScale: () => croma('blue') };
 			return barOptions({ ...graphOptions, seriesOptions });
 
 		case 'line':

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -26,7 +26,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { metric, dimension, resolution, topX, type, title, showLegend, minWidth, summarize } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth  } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -46,6 +46,11 @@ export default function Edit( { attributes, setAttributes } ) {
 	const controls = (
 		<InspectorControls>
 			<PanelBody title={__('Graph Settings')}>
+				<TextControl
+					label={ __( 'Title' ) }
+					value={ title }
+					onChange={ update('title') }
+				/>
 				<SelectControl
 					label={ __( 'Type' ) }
 					value={ type }
@@ -57,10 +62,14 @@ export default function Edit( { attributes, setAttributes } ) {
 					] }
 					onChange={ update('type') }
 				/>
-				<TextControl
-					label={ __( 'Title' ) }
-					value={ title }
-					onChange={ update('title') }
+				<SelectControl
+					label={__('Orientation')}
+					value={orientation}
+					options={[
+						{ label: __('Vertical'), value: 'vertical' },
+						{ label: __('Horizontal'), value: 'horizontal' },
+					]}
+					onChange={ update('orientation') }
 				/>
 				<ToggleControl
 					label={ __( 'Show Legend' ) }


### PR DESCRIPTION
This adds the option for horizontal bar graphs.
For now it only applies to bar graphs. We still need to rotate the data for line and area graphs

<img width="274" alt="Screenshot 2025-04-10 at 5 25 56 PM" src="https://github.com/user-attachments/assets/e18321a6-f9ed-43b0-9fed-d8c8bc21e31b" />

<img width="1474" alt="Screenshot 2025-04-10 at 5 22 53 PM" src="https://github.com/user-attachments/assets/ff4841b7-3cec-4076-988e-678572abe784" />
