### PR TITLE
Bug/temp css labels growth

### DIFF
--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -371,6 +371,7 @@ button.wpcloud-block-button {
 /* @TODO : This should use the spacing styles in from the editor */
 .wpcloud-graph {
 	margin: 20px 0;
+	max-height: 500px;
 }
 
 .wp-block-site-logo.hero-logo {
@@ -387,4 +388,10 @@ button.wpcloud-block-button {
 			height: auto;
 		}
 	}
+}
+
+/* @TODO - A multi-line legend causes the block to constantly render and grow in size. */
+.u-legend {
+	max-height: 30px;
+	overflow: hidden;
 }

--- a/theme-pico/assets/styles/global.css
+++ b/theme-pico/assets/styles/global.css
@@ -371,7 +371,6 @@ button.wpcloud-block-button {
 /* @TODO : This should use the spacing styles in from the editor */
 .wpcloud-graph {
 	margin: 20px 0;
-	max-height: 500px;
 }
 
 .wp-block-site-logo.hero-logo {


### PR DESCRIPTION
…auses the uplot to re-render attempting to correct for the size overflow. However the chart element is updating and not the space allocated for the labels and we end in an infinite loop of growing chart size. Adds temporary CSS to stop the graph growth, will need a larger fix for styling.

Temporary Fix for: https://github.com/Automattic/wpcloud-station/issues/323