### PR TITLE
Graphs :: fix issue with top_x argument not being adhered to.

### DIFF
--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$summarize = $params['summarize'] ?? false;
 
 				$options = array(
-					'top_x'      => $params['top_x'] ?? 20,
+					'max_bucket_size'      => $params['top_x'] ?? 20, // Metrics API has top_x as max_bucket_size.
 					'resolution' => $params['resolution'] ?? 10,
 				);
 


### PR DESCRIPTION
Resolves issue https://github.com/Automattic/wpcloud-station/issues/329

THe Metrics API uses "max_bucket_size" for the parameter, nomenclature from elasticsearch. We should potentially update or add an alias for top_x as that is more generic of the actual behavior and not the implementation.

This patch updates the metrics controller to map top_x to max_bucket_size when making the Metrics Request.