### PR TITLE
Metrics :: Add dependency between metric and dimension options

### DIFF
--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -91,6 +91,10 @@
 		"minWidth" : {
 			"type" : "string",
 			"default" : "500px"
+		},
+		"showFilters" : {
+			"type" : "boolean",
+			"default" : true
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -92,10 +92,6 @@
 			"type" : "string",
 			"default" : "500px"
 		},
-		"showFilters" : {
-			"type" : "boolean",
-			"default" : true
-		},
 		"predefinedFilters" : {
 			"type" : "array",
 			"default" : []
@@ -103,7 +99,7 @@
 		"allowFrontendFilters" : {
 			"type" : "boolean",
 			"default" : true,
-			"description": "Controls whether users can add, remove, or modify filters on the frontend"
+			"description": "Controls whether filters are shown and if users can add, remove, or modify them on the frontend"
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -95,6 +95,15 @@
 		"showFilters" : {
 			"type" : "boolean",
 			"default" : true
+		},
+		"predefinedFilters" : {
+			"type" : "array",
+			"default" : []
+		},
+		"allowFrontendFilters" : {
+			"type" : "boolean",
+			"default" : true,
+			"description": "Controls whether users can add, remove, or modify filters on the frontend"
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -121,7 +121,13 @@ export default function Graph( props ) {
 		id = `graph-${metric}-${dimension}`,
 
 		// Show filters toggle
-		showFilters = true
+		showFilters = true,
+
+		// Predefined filters from block attributes
+		predefinedFilters = [],
+
+		// Allow frontend filter building
+		allowFrontendFilters = true
 
 	} = props;
 
@@ -153,8 +159,43 @@ export default function Graph( props ) {
 	// Initialize filters from URL parameters if available
 	const [ filters, setFilters ] = useState([]);
 
-	// Load filters from URL on mount
+	// Convert predefined filters to filter objects
+	const convertPredefinedFilters = (filters) => {
+		if (!filters || !Array.isArray(filters) || filters.length === 0) {
+			return [];
+		}
+
+		return filters.map(filter => {
+			// Handle array format [field, operator, value]
+			if (Array.isArray(filter)) {
+				const [field, operator, value] = filter;
+				return {
+					enabled: true,
+					value: {
+						field,
+						operator,
+						value
+					},
+					compact: `${field} ${operator} ${value}`,
+					label: `${field} ${operator} ${value}`
+				};
+			}
+			return null;
+		}).filter(f => f !== null);
+	};
+
+	// Load filters from predefined filters or URL on mount
 	useEffect(() => {
+		// First check if we have predefined filters from block attributes
+		if (predefinedFilters && Array.isArray(predefinedFilters) && predefinedFilters.length > 0) {
+			const blockFilters = convertPredefinedFilters(predefinedFilters);
+			if (blockFilters.length > 0) {
+				setFilters(blockFilters);
+				return; // Use predefined filters, don't check URL
+			}
+		}
+
+		// If no predefined filters, try to get from URL
 		if (typeof window !== 'undefined') {
 			try {
 				const urlFilters = getFiltersFromUrl(graphId);
@@ -165,7 +206,7 @@ export default function Graph( props ) {
 				console.error('Error initializing filters:', error);
 			}
 		}
-	}, [graphId]);
+	}, [graphId, predefinedFilters]);
 
 	const containerRef = useRef(null);
 	// Ensure the container takes full width of parent and has appropriate minimum dimensions
@@ -299,6 +340,7 @@ export default function Graph( props ) {
 						filters={filters}
 						onFiltersUpdate={handleFiltersUpdate}
 						loading={loading}
+						allowFrontendFilters={allowFrontendFilters}
 					/>
 				</div>
 			)}

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -120,9 +120,6 @@ export default function Graph( props ) {
 		// Unique identifier for this graph
 		id = `graph-${metric}-${dimension}`,
 
-		// Show filters toggle
-		showFilters = true,
-
 		// Predefined filters from block attributes
 		predefinedFilters = [],
 
@@ -156,6 +153,7 @@ export default function Graph( props ) {
 	const [ series, setSeries ] = useState([]);
 	const [ meta, setMeta ] = useState({});
 	const [ loading, setLoading ] = useState( true );
+	const [ refreshing, setRefreshing ] = useState( false );
 	// Initialize filters from URL parameters if available
 	const [ filters, setFilters ] = useState([]);
 
@@ -225,7 +223,14 @@ export default function Graph( props ) {
 	useEffect(() => {
 		const controller = new AbortController();
 		const signal = controller.signal;
-		setLoading(true);
+
+		// If we already have data, we're refreshing rather than loading for the first time
+		if (hasData) {
+			setRefreshing(true);
+		} else {
+			setLoading(true);
+		}
+
 		async function fetchData() {
 			try {
 				// Extract active filters for the API query and ensure values are strings
@@ -264,9 +269,12 @@ export default function Graph( props ) {
 				setSeries(series);
 				setMeta(meta);
 				setLoading(false);
+				setRefreshing(false);
 			} catch (error) {
 				if (error.name !== 'AbortError') {
 					console.error(error);
+					setLoading(false);
+					setRefreshing(false);
 				}
 			}
 		}
@@ -331,15 +339,20 @@ export default function Graph( props ) {
 	return (
 		<div style={{ width: '100%' }} data-graph-id={graphId}>
 			<div ref={containerRef} className={className} style={style}>
-			{showOverlay && <Overlay loading={loading} title={title} /> }
-			{ hasData && <UplotReact options={options} data={d} /> }
+				{showOverlay && <Overlay loading={loading} title={title} /> }
+				{hasData && (
+					<>
+						<UplotReact options={options} data={d} />
+						{refreshing && <Overlay refreshing={true} />}
+					</>
+				)}
 			</div>
-			{showFilters && (
+			{allowFrontendFilters && (
 				<div style={{ position: 'relative', marginTop: '10px', zIndex: 1 }}>
 					<Filters
 						filters={filters}
 						onFiltersUpdate={handleFiltersUpdate}
-						loading={loading}
+						loading={loading || refreshing}
 						allowFrontendFilters={allowFrontendFilters}
 					/>
 				</div>

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -19,6 +19,79 @@ import Overlay from './overlay';
 import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
+import Filters from './lib/filters';
+
+/**
+ * Parse URL parameters to get filters for a specific graph
+ *
+ * @param {string} graphId - The unique ID of the graph
+ * @returns {Array} - Array of filter objects
+ */
+const getFiltersFromUrl = (graphId) => {
+	try {
+		// Get the URL search parameters
+		const urlParams = new URLSearchParams(window.location.search);
+
+		// Look specifically for the parameter with this graph's ID
+		const paramName = `filters_${graphId}`;
+		const filterParam = urlParams.get(paramName);
+
+		// If there's no parameter specifically for this graph, return empty array
+		if (!filterParam) {
+			return [];
+		}
+
+		// Parse the JSON string from the URL
+		const decodedFilters = JSON.parse(decodeURIComponent(filterParam));
+
+		// Convert the array format to the filter object format
+		return decodedFilters.map(filter => ({
+			enabled: true,
+			value: {
+				field: filter[0],
+				operator: filter[1],
+				value: filter[2]
+			},
+			compact: `${filter[0]} ${filter[1]} ${filter[2]}`,
+			label: `${filter[0]} ${filter[1]} ${filter[2]}`
+		}));
+	} catch (error) {
+		console.error('Error parsing filters from URL:', error);
+		return [];
+	}
+};
+
+/**
+ * Update URL parameters with filters for a specific graph
+ *
+ * @param {string} graphId - The unique ID of the graph
+ * @param {Array} filters - Array of filter objects
+ */
+const updateUrlWithFilters = (graphId, filters) => {
+	try {
+		// Get the active filters in array format
+		const activeFilters = filters
+			.filter(f => f.enabled)
+			.map(f => [f.value.field, f.value.operator, String(f.value.value)]);
+
+		// Get the current URL search parameters
+		const urlParams = new URLSearchParams(window.location.search);
+
+		// If there are active filters, add them to the URL
+		if (activeFilters.length > 0) {
+			urlParams.set(`filters_${graphId}`, encodeURIComponent(JSON.stringify(activeFilters)));
+		} else {
+			// If there are no active filters, remove the parameter
+			urlParams.delete(`filters_${graphId}`);
+		}
+
+		// Update the URL without reloading the page
+		const newUrl = `${window.location.pathname}?${urlParams.toString()}${window.location.hash}`;
+		window.history.replaceState({}, '', newUrl);
+	} catch (error) {
+		console.error('Error updating URL with filters:', error);
+	}
+};
 
 export default function Graph( props ) {
 
@@ -42,9 +115,34 @@ export default function Graph( props ) {
 		orientation,
 
 		// Dynamic metric props.
-		interval, refresh
+		interval, refresh,
+
+		// Unique identifier for this graph
+		id = `graph-${metric}-${dimension}`,
+
+		// Show filters toggle
+		showFilters = true
 
 	} = props;
+
+	// Create a deterministic ID based on the graph's properties
+	// This will be the same across page loads for the same graph
+	const generateStableId = (metric, dimension, title) => {
+		// Create a string that uniquely identifies this graph
+		const baseString = `${metric}-${dimension}-${title}`;
+		// Simple hash function to generate a numeric hash
+		let hash = 0;
+		for (let i = 0; i < baseString.length; i++) {
+			const char = baseString.charCodeAt(i);
+			hash = ((hash << 5) - hash) + char;
+			hash = hash & hash; // Convert to 32bit integer
+		}
+		// Convert to a positive number and return
+		return `${id.replace(/[^a-zA-Z0-9-_]/g, '-')}-${Math.abs(hash)}`;
+	};
+
+	// Generate a stable ID that will be the same across page loads
+	const graphId = generateStableId(metric, dimension, title);
 
 	const { apiPath } = useApiContext();
 	const { start, end } = interval || {};
@@ -52,9 +150,32 @@ export default function Graph( props ) {
 	const [ series, setSeries ] = useState([]);
 	const [ meta, setMeta ] = useState({});
 	const [ loading, setLoading ] = useState( true );
+	// Initialize filters from URL parameters if available
+	const [ filters, setFilters ] = useState([]);
+
+	// Load filters from URL on mount
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			try {
+				const urlFilters = getFiltersFromUrl(graphId);
+				if (urlFilters && Array.isArray(urlFilters) && urlFilters.length > 0) {
+					setFilters(urlFilters);
+				}
+			} catch (error) {
+				console.error('Error initializing filters:', error);
+			}
+		}
+	}, [graphId]);
 
 	const containerRef = useRef(null);
-	const style = { position: "relative", minWidth, minHeight: '500px', ...styles };
+	// Ensure the container takes full width of parent and has appropriate minimum dimensions
+	const style = {
+		position: "relative",
+		width: '100%',
+		minWidth,
+		minHeight: '500px',
+		...styles
+	};
 	// if the className does not contain has-background add a background color
 	if ( ! className.includes( 'has-background' ) ) {
 		styles.backgroundColor = 'white';
@@ -66,15 +187,37 @@ export default function Graph( props ) {
 		setLoading(true);
 		async function fetchData() {
 			try {
+				// Extract active filters for the API query and ensure values are strings
+				const activeFilters = filters.filter(f => f.enabled).map(f => {
+					// Ensure the value is a string to avoid PHP strpos() errors
+					return [
+						f.value.field,
+						f.value.operator,
+						// Convert all values to strings to avoid PHP type errors
+						String(f.value.value)
+					];
+				});
+
+				// Create the query parameters
+				const queryParams = {
+					start,
+					end,
+					dimension,
+					resolution,
+					summarize,
+					top_x: topX,
+				};
+
+				// Only add filters if there are any active ones
+				// Stringify the filters array to ensure it's sent as a JSON array
+				if (activeFilters.length > 0) {
+					queryParams.filters = JSON.stringify(activeFilters);
+				}
+
 				const { data, series, meta } = await stationApi.get( `${apiPath}/${metric}`, {
-					query: {
-						start,
-						end,
-						dimension,
-						resolution,
-						summarize,
-						top_x: topX,
-					}, parse: true, signal
+					query: queryParams,
+					parse: true,
+					signal
 				});
 				setData(data);
 				setSeries(series);
@@ -89,7 +232,7 @@ export default function Graph( props ) {
 
 		fetchData();
 		return () => controller.abort();
-	}, [ apiPath, start, end, refresh ] );
+	}, [ apiPath, start, end, refresh, filters ] );
 
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type, orientation });
@@ -104,10 +247,61 @@ export default function Graph( props ) {
 
 	const showOverlay = loading || !hasData;
 	//
+	// Handle filter updates
+	const handleFiltersUpdate = ({ filters: newFilters }) => {
+		const processedFilters = newFilters.map(filter => {
+			// Handle both array format [field, operator, value] and object format {field, operator, value}
+			let field, operator, value;
+
+			if (Array.isArray(filter)) {
+				// Array format: [field, operator, value]
+				field = filter[0];
+				operator = filter[1];
+				value = filter[2];
+			} else {
+				// Object format: {field, operator, value}
+				field = filter.field;
+				operator = filter.operator;
+				value = filter.value;
+			}
+
+			// Convert value to string for display
+			const valueStr = String(value);
+
+			return {
+				enabled: true,
+				value: {
+					field,
+					operator,
+					value
+				},
+				compact: `${field} ${operator} ${valueStr}`,
+				label: `${field} ${operator} ${valueStr}`
+			};
+		});
+
+		// Update the state with the new filters
+		setFilters(processedFilters);
+
+		// Update the URL with the new filters
+		updateUrlWithFilters(graphId, processedFilters);
+	};
+
 	return (
-		<div ref={containerRef} className={className} style={style}>
+		<div style={{ width: '100%' }} data-graph-id={graphId}>
+			<div ref={containerRef} className={className} style={style}>
 			{showOverlay && <Overlay loading={loading} title={title} /> }
 			{ hasData && <UplotReact options={options} data={d} /> }
+			</div>
+			{showFilters && (
+				<div style={{ position: 'relative', marginTop: '10px', zIndex: 1 }}>
+					<Filters
+						filters={filters}
+						onFiltersUpdate={handleFiltersUpdate}
+						loading={loading}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
+++ b/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
@@ -1,0 +1,232 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    Panel,
+    PanelBody,
+    PanelRow,
+    SelectControl,
+    TextControl,
+    Icon
+} from '@wordpress/components';
+import { trash } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+
+// Field options (dimensions) - same as in filtersForm.js
+const fieldOptions = {
+    'http_verb': __('HTTP Verb'),
+    'http_status': __('HTTP Status')
+};
+
+// Operator options - same as in filtersForm.js
+const operatorOptions = {
+    '=': __('is'),
+    '!=': __('is not'),
+    'IN': __('is one of'),
+    'NOT IN': __('is not one of'),
+    '>': __('greater than'),
+    '>=': __('greater than or equal to'),
+    '<': __('less than'),
+    '<=': __('less than or equal to'),
+};
+
+// Validator function to check if the field allows the operator
+const isOperatorValidForField = (field, operator) => {
+    // For now, always return true
+    // This can be expanded later to validate specific operators for different fields
+    return true;
+};
+
+// Check if operator accepts multiple values
+const operatorAcceptsMultipleValues = (operator) => {
+    return operator === 'IN' || operator === 'NOT IN';
+};
+
+/**
+ * Convert a filter from the array format [field, operator, value] to an object format
+ *
+ * @param {Array} filter - Filter in array format [field, operator, value]
+ * @returns {Object} - Filter in object format {field, operator, value}
+ */
+const arrayToObjectFilter = (filter) => {
+    if (Array.isArray(filter)) {
+        return {
+            field: filter[0],
+            operator: filter[1],
+            value: filter[2]
+        };
+    }
+    return filter;
+};
+
+/**
+ * Convert a filter from the object format {field, operator, value} to an array format
+ *
+ * @param {Object} filter - Filter in object format {field, operator, value}
+ * @returns {Array} - Filter in array format [field, operator, value]
+ */
+const objectToArrayFilter = (filter) => {
+    if (filter && typeof filter === 'object' && !Array.isArray(filter)) {
+        return [filter.field, filter.operator, filter.value];
+    }
+    return filter;
+};
+
+/**
+ * Component for building and managing predefined filters in the block editor
+ */
+export default function FilterBuilder({ filters = [], onChange }) {
+    const [field, setField] = useState('');
+    const [operator, setOperator] = useState('');
+    const [value, setValue] = useState('');
+
+    const handleFieldChange = (newField) => {
+        setField(newField);
+    };
+
+    const handleOperatorChange = (newOperator) => {
+        setOperator(newOperator);
+    };
+
+    const handleValueChange = (newValue) => {
+        setValue(newValue);
+    };
+
+    const resetForm = () => {
+        setField('');
+        setOperator('');
+        setValue('');
+    };
+
+    const handleAddFilter = () => {
+        if (field && operator && value) {
+            // Convert value to number if it's numeric and using a numeric comparison operator
+            let processedValue = value;
+            if (['>','>=','<','<='].includes(operator) && !isNaN(Number(value))) {
+                processedValue = Number(value);
+            } else if (field === 'http_status' && !isNaN(Number(value))) {
+                // HTTP status codes should be numbers
+                processedValue = Number(value);
+            }
+
+            // Create the new filter in array format [field, operator, value]
+            const newFilter = [field, operator, processedValue];
+
+            // Add the new filter to the existing filters
+            const updatedFilters = [...filters, newFilter];
+
+            // Call the onChange callback with the updated filters
+            onChange(updatedFilters);
+
+            // Reset the form
+            resetForm();
+        }
+    };
+
+    const handleRemoveFilter = (indexToRemove) => {
+        const updatedFilters = filters.filter((_, index) => index !== indexToRemove);
+        onChange(updatedFilters);
+    };
+
+    return (
+        <div className="wpcloud-filter-builder">
+            <PanelBody title={__('Predefined Filters')} initialOpen={false}>
+                <PanelRow>
+                    <div style={{ width: '100%' }}>
+                        <Flex direction="column" gap={4}>
+                            {/* Filter input form */}
+                            <Flex direction="column" gap={2}>
+                                <SelectControl
+                                    label={__('Field')}
+                                    value={field}
+                                    options={[
+                                        { label: __('Select a field'), value: '' },
+                                        ...Object.entries(fieldOptions).map(([value, label]) => ({
+                                            label,
+                                            value
+                                        }))
+                                    ]}
+                                    onChange={handleFieldChange}
+                                />
+
+                                <SelectControl
+                                    label={__('Operator')}
+                                    value={operator}
+                                    options={[
+                                        { label: __('Select an operator'), value: '' },
+                                        ...Object.entries(operatorOptions).map(([value, label]) => ({
+                                            label,
+                                            value,
+                                            disabled: field && !isOperatorValidForField(field, value)
+                                        }))
+                                    ]}
+                                    onChange={handleOperatorChange}
+                                    disabled={!field}
+                                />
+
+                                <TextControl
+                                    label={__('Value')}
+                                    value={value}
+                                    onChange={handleValueChange}
+                                    placeholder={
+                                        operatorAcceptsMultipleValues(operator)
+                                            ? __('Value one, Value two, ...')
+                                            : __('Value')
+                                    }
+                                    disabled={!field || !operator}
+                                />
+
+                                <Button
+                                    variant="primary"
+                                    onClick={handleAddFilter}
+                                    disabled={!field || !operator || !value}
+                                >
+                                    {__('Add Filter')}
+                                </Button>
+                            </Flex>
+
+                            {/* List of existing filters */}
+                            {filters.length > 0 && (
+                                <div className="wpcloud-filter-builder__filters">
+                                    <h3>{__('Current Filters')}</h3>
+                                    <Flex direction="column" gap={2}>
+                                        {filters.map((filter, index) => {
+                                            // Convert to object format for easier access
+                                            const f = arrayToObjectFilter(filter);
+                                            return (
+                                                <Flex key={index} align="center" justify="space-between">
+                                                    <span>
+                                                        {`${f.field} ${f.operator} ${f.value}`}
+                                                    </span>
+                                                    <Button
+                                                        isDestructive
+                                                        icon={trash}
+                                                        onClick={() => handleRemoveFilter(index)}
+                                                        label={__('Remove filter')}
+                                                        showTooltip
+                                                    />
+                                                </Flex>
+                                            );
+                                        })}
+                                    </Flex>
+                                </div>
+                            )}
+                        </Flex>
+                    </div>
+                </PanelRow>
+            </PanelBody>
+        </div>
+    );
+}

--- a/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
+++ b/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
@@ -142,7 +142,7 @@ export default function FilterBuilder({ filters = [], onChange }) {
 
     return (
         <div className="wpcloud-filter-builder">
-            <PanelBody title={__('Predefined Filters')} initialOpen={false}>
+            <PanelBody title={__('Graph Filters')} initialOpen={false}>
                 <PanelRow>
                     <div style={{ width: '100%' }}>
                         <Flex direction="column" gap={4}>

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -90,7 +90,7 @@ const updateFilters = (onFilterUpdate, setFilters) => {
 	});
 }
 
-export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false }) => {
+export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false, allowFrontendFilters = true }) => {
 	const [filters, setFilters] = useState([]);
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -168,15 +168,17 @@ export default ({ onFiltersUpdate = console.log, filters: propFilters = [], load
 							<span className="wpcloud-metrics-filters__filter-text">
 								{filter.compact}
 							</span>
-							<Icon
-								onClick={(e) => {
-									e.stopPropagation(); // Stop event from bubbling up to parent button
-									handleFilterRemove(index);
-								}}
-								icon={trash} size={20} />
+							{allowFrontendFilters && (
+								<Icon
+									onClick={(e) => {
+										e.stopPropagation(); // Stop event from bubbling up to parent button
+										handleFilterRemove(index);
+									}}
+									icon={trash} size={20} />
+							)}
 						</button>
 					))}
-					<FiltersForm onFilterAdd={handleFilterAdd} />
+					{allowFrontendFilters && <FiltersForm onFilterAdd={handleFilterAdd} />}
 				</Flex>
 			</div>
 		</div>

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -1,0 +1,184 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Flex, FlexItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, trash } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import FiltersForm from './filtersForm';
+
+
+const buildFilter = (filter, enabled = true) => {
+	// Handle different filter formats
+	let field, operator, value;
+
+	if (Array.isArray(filter)) {
+		// Array format: [field, operator, value]
+		[field, operator, value] = filter;
+	} else if (filter && typeof filter === 'object') {
+		// Object format: {field, operator, value} or {value: {field, operator, value}}
+		if (filter.value && filter.value.field) {
+			// Format: {value: {field, operator, value}}
+			field = filter.value.field;
+			operator = filter.value.operator;
+			value = filter.value.value;
+		} else {
+			// Format: {field, operator, value}
+			field = filter.field;
+			operator = filter.operator;
+			value = filter.value;
+		}
+	} else {
+		// Invalid format, provide defaults
+		field = '';
+		operator = '=';
+		value = '';
+	}
+
+	// Ensure all values are defined
+	field = field || '';
+	operator = operator || '=';
+	value = value !== undefined ? value : '';
+
+	// Convert value to string for display
+	const valueStr = String(value);
+	const hasMultipleWords = valueStr.trim().includes(' ') || valueStr.trim().includes(',');
+	const label = `${field} ${operator} ${valueStr}`;
+
+	return {
+		enabled,
+		value: {
+			field,
+			operator,
+			// Store the original value to maintain type for API calls
+			value,
+		},
+		// Use the string version for display
+		compact: hasMultipleWords ? `${field} ${operator} ...` : label,
+		label,
+	}
+}
+
+const updateFilters = (onFilterUpdate, setFilters) => {
+	return (filters => {
+		setFilters(filters);
+		// Extract the field, operator, and value from each filter and create an array format
+		// that the API expects: [field, operator, value]
+		const filterList = filters
+			.filter(f => f.enabled)
+			.map(f => {
+				// Ensure the filter has the expected structure
+				if (f.value && f.value.field && f.value.operator && f.value.value !== undefined) {
+					// Convert value to string to avoid PHP strpos() errors
+					return [f.value.field, f.value.operator, String(f.value.value)];
+				}
+				// Fallback for unexpected filter format
+				return null;
+			})
+			.filter(f => f !== null); // Remove any null entries
+
+		onFilterUpdate({ filters: filterList });
+	});
+}
+
+export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false }) => {
+	const [filters, setFilters] = useState([]);
+	const [isOpen, setIsOpen] = useState(false);
+
+	useEffect(() => {
+		if (propFilters.length > 0) {
+			const updatedFilters = propFilters.map(filter => buildFilter(filter));
+			setFilters(updatedFilters);
+		}
+	}, [propFilters]);
+
+
+	const handleFilterUpdate =  updateFilters(onFiltersUpdate, setFilters);
+
+	const handleFilterAdd = (filter) => {
+		const updatedFilters = [...filters, buildFilter(filter)];
+		handleFilterUpdate(updatedFilters);
+	};
+
+	const handleFilterRemove = (indexToRemove) => {
+		const updatedFilters = filters.filter((_, index) => index !== indexToRemove);
+		handleFilterUpdate(updatedFilters);
+	};
+
+	const handleToggleFilter = (indexToDisable) => {
+		const updatedFilters = filters.map((filter, index) => {
+			if (index === indexToDisable) {
+				return { ...filter, enabled: !filter.enabled };
+			}
+			return filter;
+		});
+		handleFilterUpdate(updatedFilters);
+	}
+	const toggleOpen = () => {
+		if (!loading) {
+			setIsOpen(!isOpen);
+		}
+	};
+
+	return (
+		<div className="wpcloud-metrics-filters__container" style={{ position: 'relative' }}>
+			<summary
+				onClick={toggleOpen}
+				style={{
+					cursor: loading ? 'not-allowed' : 'pointer',
+					opacity: loading ? 0.6 : 1
+				}}
+			>
+				{filters.length > 0 ? __(`Filters (${filters.filter(f => f.enabled).length})`) : __('Filters')}
+			</summary>
+			<div
+				className="wpcloud-metrics-filters"
+				style={{
+					display: isOpen ? 'block' : 'none',
+					position: 'absolute',
+					zIndex: 1000,
+					background: 'white',
+					boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
+					padding: '10px',
+					borderRadius: '4px',
+					width: '100%'
+				}}
+			>
+				<Flex className="wpcloud-metrics-filters__applied" justify="start" wrap="wrap" style={{ gap: '8px' }}>
+					{filters.map((filter, index) => (
+						<button
+							key={index}
+							className={
+								classnames(
+									"wpcloud-metrics-filters__filter secondary",
+									{ "disabled": !filter.enabled }
+								)}
+							{ ...( filter.compact != filter.detailed && { 'data-tooltip': filter.label } ) }
+							onClick={() => handleToggleFilter(index)}
+						>
+							<span className="wpcloud-metrics-filters__filter-text">
+								{filter.compact}
+							</span>
+							<Icon
+								onClick={(e) => {
+									e.stopPropagation(); // Stop event from bubbling up to parent button
+									handleFilterRemove(index);
+								}}
+								icon={trash} size={20} />
+						</button>
+					))}
+					<FiltersForm onFilterAdd={handleFilterAdd} />
+				</Flex>
+			</div>
+		</div>
+	)
+};

--- a/plugin/blocks/src/components/graph/components/lib/filtersForm.js
+++ b/plugin/blocks/src/components/graph/components/lib/filtersForm.js
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { FlexItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+// Field options (dimensions)
+const fieldOptions = {
+		'http_verb': __('HTTP Verb'),
+		'http_status': __('HTTP Status')
+};
+
+// Operator options
+const operatorOptions = {
+		'=': __('is'),
+		'!=': __('is not'),
+		'IN': __('is one of'),
+		'NOT IN': __('is not one of'),
+		'>': __('greater than'),
+		'>=': __('greater than or equal to'),
+		'<': __('less than'),
+		'<=': __('less than or equal to'),
+};
+
+// Validator function to check if the field allows the operator
+const isOperatorValidForField = (field, operator) => {
+		// For now, always return true
+		// This can be expanded later to validate specific operators for different fields
+		return true;
+};
+
+// Check if operator accepts multiple values
+const operatorAcceptsMultipleValues = (operator) => {
+		return operator === 'IN' || operator === 'NOT IN';
+};
+
+export default ({ onFilterAdd = () => {} }) => {
+		const [field, setField] = useState('');
+		const [operator, setOperator] = useState('');
+		const [value, setValue] = useState('');
+		const [isOpen, setIsOpen] = useState(false);
+
+		const handleFieldChange = (event) => {
+				setField(event.target.value);
+		};
+
+		const handleOperatorChange = (event) => {
+				setOperator(event.target.value);
+		};
+
+		const handleValueChange = (event) => {
+				setValue(event.target.value);
+		};
+
+		const resetForm = () => {
+				setField('');
+				setOperator('');
+				setValue('');
+		};
+
+		const handleAddFilter = () => {
+				if (field && operator && value) {
+						// Convert value to number if it's numeric and using a numeric comparison operator
+						let processedValue = value;
+						if (['>','>=','<','<='].includes(operator) && !isNaN(Number(value))) {
+								processedValue = Number(value);
+						} else if (field === 'http_status' && !isNaN(Number(value))) {
+								// HTTP status codes should be numbers
+								processedValue = Number(value);
+						}
+
+						onFilterAdd({ field, operator, value: processedValue });
+						resetForm();
+						setIsOpen(false); // Close the dropdown after adding a filter
+				}
+		};
+
+		const handleKeyDown = (event) => {
+				if (event.key === 'Enter' && field && operator && value) {
+						event.preventDefault();
+						handleAddFilter();
+				}
+		};
+
+		return (
+			<details
+					className="wpcloud-metrics-filters-picker no-border dropdown"
+					open={isOpen}
+					onToggle={(e) => setIsOpen(e.target.open)}
+					style={{ position: 'relative' }}
+			>
+					<summary style={{width: 'fit-content', marginLeft: '6px'}}>{__('+ Add Filter')}</summary>
+					<ul className="wpcloud-metrics-filters-picker__options" style={{ position: 'absolute', zIndex: 1000, background: 'white', boxShadow: '0 2px 5px rgba(0,0,0,0.2)', width: '400px', maxWidth: '100vw' }}>
+							<li>
+									<div className="wpcloud-metrics-filters-picker__controls">
+											<div className="wpcloud-metrics-filters-picker__inputs">
+													<div className="wpcloud-metrics-filters-picker__field">
+															<label htmlFor="filter-field" className="screen-reader-text">{__('Field')}</label>
+															<select
+																	id="filter-field"
+																	value={field}
+																	onChange={handleFieldChange}
+																	aria-label={__('Field')}
+															>
+																	<option value="">{__('Field')}</option>
+																	{Object.entries(fieldOptions).map(([value, label]) => (
+																			<option key={value} value={value}>{label}</option>
+																	))}
+															</select>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__operator">
+															<label htmlFor="filter-operator" className="screen-reader-text">{__('Operator')}</label>
+															<select
+																	id="filter-operator"
+																	value={operator}
+																	onChange={handleOperatorChange}
+																	disabled={!field}
+																	aria-label={__('Operator')}
+															>
+																	<option value="">{__('Operator')}</option>
+																	{Object.entries(operatorOptions).map(([value, label]) => (
+																			<option
+																					key={value}
+																					value={value}
+																					disabled={field && !isOperatorValidForField(field, value)}
+																			>
+																					{label}
+																			</option>
+																	))}
+															</select>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__value">
+															<label htmlFor="filter-value" className="screen-reader-text">{__('Value')}</label>
+															<input
+																	type="text"
+																	id="filter-value"
+																	value={value}
+																	onChange={handleValueChange}
+																	onKeyDown={handleKeyDown}
+																	disabled={!field || !operator}
+																	placeholder={operatorAcceptsMultipleValues(operator) ? __('Value one, Value two, ...') : __('Value')}
+																	aria-label={__('Value')}
+															/>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__apply">
+															<button
+																	onClick={handleAddFilter}
+																	disabled={!field || !operator || !value}
+															>
+																	{__('Apply')}
+															</button>
+													</div>
+											</div>
+									</div>
+							</li>
+					</ul>
+			</details>
+		);
+};

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -3,7 +3,8 @@ import { stackedOptions, defaultOptions, barOptions, lineOptions, areaOptions } 
 
 // Remove this amount from the container height to fit the graph legend.
 const fitGraphHeight = 75;
-const fitGraphWidth = 20;
+// Reduced the width adjustment to ensure graphs aren't too skinny
+const fitGraphWidth = 10;
 
 export default (options) => {
 	const {
@@ -17,29 +18,38 @@ export default (options) => {
 		orientation,
 	} = options;
 
-	const [width, setWidth] = useState(808);
-	const [height, setHeight] = useState(404);
+	// Set more appropriate initial values for flex containers
+	const [width, setWidth] = useState(containerRef?.current?.offsetWidth || 808);
+	const [height, setHeight] = useState(containerRef?.current?.offsetHeight || 404);
 
 	useEffect(() => {
 		const updateSize = () => {
 			if ( containerRef.current ) {
-				setWidth( containerRef.current.offsetWidth - fitGraphWidth );
-				setHeight( containerRef.current.offsetHeight - fitGraphHeight );
+				const newWidth = containerRef.current.offsetWidth - fitGraphWidth;
+				const newHeight = containerRef.current.offsetHeight - fitGraphHeight;
+
+				// Only update if the size has actually changed
+				if (newWidth !== width || newHeight !== height) {
+					setWidth(newWidth);
+					setHeight(newHeight);
+				}
 			}
 		};
 
 		updateSize(); // Initial update
 
-		const resizeObserver = new ResizeObserver( () => {
+		const resizeObserver = new ResizeObserver(() => {
 			if (containerRef.current) {
 				updateSize();
 			}
 		});
+
 		if (containerRef.current) {
-			resizeObserver.observe( containerRef.current );
+			resizeObserver.observe(containerRef.current);
 		}
+
 		return () => resizeObserver.disconnect();
-	}, [ containerRef ]);
+	}, [containerRef, width, height]);
 
 	let graphOptions = {
 		title,

--- a/plugin/blocks/src/components/graph/components/overlay.js
+++ b/plugin/blocks/src/components/graph/components/overlay.js
@@ -5,7 +5,48 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export default ({ loading, title }) => {
+/**
+ * Enhanced Overlay component that can handle both initial loading and refreshing states
+ *
+ * @param {Object} props Component props
+ * @param {boolean} props.loading Whether data is loading initially
+ * @param {boolean} props.refreshing Whether data is being refreshed
+ * @param {string} props.title Graph title for no data message
+ * @returns {JSX.Element} Overlay component
+ */
+export default ({ loading, refreshing = false, title }) => {
+	// If refreshing, show a semi-transparent overlay with just the spinner
+	if (refreshing) {
+		return (
+			<div
+				style={{
+					position: 'absolute',
+					top: 0,
+					left: 0,
+					right: 0,
+					bottom: 0,
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					backgroundColor: 'rgba(255, 255, 255, 0.5)',
+					zIndex: 10
+				}}
+			>
+				<div
+					role="status"
+					aria-label={__('Refreshing data', 'wpcloud')}
+					aria-live="polite"
+				>
+					<Spinner style={{
+						height: 'calc(4px * 20)',
+						width: 'calc(4px * 20)'
+					}} />
+				</div>
+			</div>
+		);
+	}
+
+	// For initial loading or no data, show the full overlay
 	return (
 		<>
 			<div

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -26,7 +26,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth  } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -151,6 +151,11 @@ export default function Edit( { attributes, setAttributes } ) {
 					label={ __( 'Show Legend' ) }
 					checked={ showLegend }
 					onChange={ update('showLegend') }
+				/>
+				<ToggleControl
+					label={ __( 'Show Filters' ) }
+					checked={ showFilters }
+					onChange={ update('showFilters') }
 				/>
 			</PanelBody>
 			<PanelBody title={__('Graph Data')}>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -48,6 +48,7 @@ export default function Edit( { attributes, setAttributes } ) {
 		fetchAvailable();
 	}, []);
 
+<<<<<<< HEAD
 	// Define all possible options for Dimensions based on Metrics
 	// @TODo - Move this to use the php function so single mapping?
 	//  Or alternatively update the json response to contain the mapping groups so not making multiple calls.
@@ -123,6 +124,11 @@ export default function Edit( { attributes, setAttributes } ) {
 			}
 		}
 	}, [metric] );
+=======
+	useEffect( () => {
+
+	}, [summarize] )
+>>>>>>> 848432e (Graph Block : Hide resolution if summarize is requested.)
 
 	const controls = (
 		<InspectorControls>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -23,10 +23,15 @@ import apiFetch from '@wordpress/api-fetch';
 import { updateAttribute } from '@wpcloud/controls';
 import './editor.scss';
 
+/**
+ * Internal dependencies
+ */
+import FilterBuilder from './components/lib/filterBuilder';
+
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters, predefinedFilters, allowFrontendFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -153,7 +158,8 @@ export default function Edit( { attributes, setAttributes } ) {
 					onChange={ update('showLegend') }
 				/>
 				<ToggleControl
-					label={ __( 'Show Filters' ) }
+					label={ __( 'Enable Filter Controls' ) }
+					help={ __( 'Allow users to view and interact with filters on the frontend. See the `Predefined Filters` section below to add default filters' ) }
 					checked={ showFilters }
 					onChange={ update('showFilters') }
 				/>
@@ -229,7 +235,25 @@ export default function Edit( { attributes, setAttributes } ) {
 					value={ minWidth }
 					onChange={ update('minWidth') }
 				/>
-				</PanelBody>
+			</PanelBody>
+
+			{showFilters && (
+				<>
+					<PanelBody title={__('Filter Settings')}>
+						<ToggleControl
+							label={ __( 'Allow Frontend Filter Building' ) }
+							help={ __( 'Enable users to add and remove filters on the frontend' ) }
+							checked={ allowFrontendFilters }
+							onChange={ update('allowFrontendFilters') }
+						/>
+					</PanelBody>
+
+					<FilterBuilder
+						filters={predefinedFilters}
+						onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+					/>
+				</>
+			)}
 		</InspectorControls>
 	)
 	return (

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -48,7 +48,6 @@ export default function Edit( { attributes, setAttributes } ) {
 		fetchAvailable();
 	}, []);
 
-<<<<<<< HEAD
 	// Define all possible options for Dimensions based on Metrics
 	// @TODo - Move this to use the php function so single mapping?
 	//  Or alternatively update the json response to contain the mapping groups so not making multiple calls.
@@ -124,11 +123,6 @@ export default function Edit( { attributes, setAttributes } ) {
 			}
 		}
 	}, [metric] );
-=======
-	useEffect( () => {
-
-	}, [summarize] )
->>>>>>> 848432e (Graph Block : Hide resolution if summarize is requested.)
 
 	const controls = (
 		<InspectorControls>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -30,18 +30,94 @@ export default function Edit( { attributes, setAttributes } ) {
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
-	const [dimensions, setDimensions] = useState({});
+	const [dimensionOptions, setDimensionOptions] = useState({});
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
 		async function fetchAvailable() {
 			const available = await apiFetch({ path: 'wpcloud-station/v1/metrics/available' });
 			setMetrics(available.metrics);
-			setDimensions(available.dimensions);
+			//setDimensions(available.dimensions);
 			setLoading(false);
 		}
 		fetchAvailable();
 	}, []);
+
+	// Define all possible options for Dimensions based on Metrics
+	// @TODo - Move this to use the php function so single mapping?
+	//  Or alternatively update the json response to contain the mapping groups so not making multiple calls.
+	const getDimensionsMap = function( metric ) {
+		if( metric.startsWith( 'php_') && metric !== 'php_response_time_sum' ) {
+			return [
+				{ label: 'HTTP Verb', value: 'http_verb' },
+				{ label: 'HTTP Host', value: 'http_host' },
+				{ label: 'DataCenter', value: 'datacenter' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+				{ label: 'Burst Status', value: 'burst_status' },
+			];
+		} else if ( metric.startsWith( 'mysql_pool_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+			];
+		} else if ( metric.startsWith( 'mysql_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			];
+		}else if ( metric.startsWith( 'cgroup_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			];
+		} else if ( metric === 'uniques' || metric === 'views' ) {
+			return [
+				{ label: 'Host Name', value: 'hostname' },
+			];
+		}
+		return [
+			{ label: 'Server Protocol (HTTP Version)', value: 'server_protocol' },
+			{ label: 'Request Method (HTTP Verb)', value: 'request_method' },
+			{ label: 'Host Name', value: 'http_host' },
+			{ label: 'Response Code (HTTP Status)', value: 'http_status' },
+			{ label: 'User Agent', value: 'http_user_agent' },
+			{ label: 'Referer Domain', value: 'referer_domain' },
+			{ label: 'Request Renderer', value: 'request_renderer' },
+			{ label: 'Is Upstream Cached?', value: 'is_upstream_cached' },
+			{ label: 'WP Admin Ajax Action', value: 'admin_ajax_action' },
+			{ label: 'Visitor ASN', value: 'asn' },
+			{ label: 'Visitor Country Code', value: 'country_code' },
+			{ label: 'Visitor Is Crawler?', value: 'is_crawler' },
+			{ label: 'Visitor Device Type', value: 'device_type' },
+			{ label: 'Visitor Is Logged In?', value: 'visitor_is_logged_in' },
+			{ label: 'Visitor Operating System', value: 'visitor_os' },
+			{ label: 'Visitor Browser', value: 'visitor_browser' },
+			{ label: 'Edge Cache Status', value: 'edge_cache_status' },
+			{ label: 'Is Rate Limited?', value: 'is_rate_limited' },
+			{ label: 'Rate Limit Reason', value: 'rate_limit_reason' },
+			{ label: 'DataCenter', value: 'datacenter' },
+			{ label: 'Request URL (excluding Query String)', value: 'request_url_no_qs' },
+			{ label: 'Remote Address', value: 'remote_addr' },
+			{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			{ label: 'Proxy Type', value: 'proxy_type' },
+		]
+	};
+
+	// Update Dimension Options when Metric is selected.
+	useEffect( () => {
+		// Update Dimension options when metrics changes
+		if ( metrics ) {
+			// @ToDo - don't update if in same map.
+			var _dimensionOptions = getDimensionsMap(metric);
+			setDimensionOptions(_dimensionOptions);
+			// update dimension if map has changed.
+			if (! _dimensionOptions.some(dimObj => dimObj.value === dimension)) {
+				setAttributes({ 'dimension': _dimensionOptions[0].value });
+			}
+		}
+	}, [metric] );
 
 	const controls = (
 		<InspectorControls>
@@ -90,7 +166,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						<SelectControl
 							label={__('Dimension')}
 							value={dimension}
-							options={Object.keys(dimensions).map((key) => ({ label: dimensions[key], value: key })) }
+							options={[ ...dimensionOptions, ]}
 							onChange={update('dimension')}
 						/>
 						<SelectControl

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -229,6 +229,11 @@ export default function Edit( { attributes, setAttributes } ) {
 
 			</PanelBody>
 
+			<FilterBuilder
+				filters={predefinedFilters}
+				onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+			/>
+
 			<PanelBody title={__('Graph Size')}>
 				<TextControl
 					label={ __( 'Minimum Width' ) }
@@ -237,12 +242,6 @@ export default function Edit( { attributes, setAttributes } ) {
 				/>
 			</PanelBody>
 
-			{allowFrontendFilters && (
-				<FilterBuilder
-					filters={predefinedFilters}
-					onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
-				/>
-			)}
 		</InspectorControls>
 	)
 	return (

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -110,7 +110,7 @@ export default function Edit( { attributes, setAttributes } ) {
 		// Update Dimension options when metrics changes
 		if ( metrics ) {
 			// @ToDo - don't update if in same map.
-			var _dimensionOptions = getDimensionsMap(metric);
+			const _dimensionOptions = getDimensionsMap(metric);
 			setDimensionOptions(_dimensionOptions);
 			// update dimension if map has changed.
 			if (! _dimensionOptions.some(dimObj => dimObj.value === dimension)) {
@@ -169,33 +169,6 @@ export default function Edit( { attributes, setAttributes } ) {
 							options={[ ...dimensionOptions, ]}
 							onChange={update('dimension')}
 						/>
-						<SelectControl
-							label={__('Resolution')}
-							value={resolution}
-							options={[
-								{ label: __('10 Seconds'), value: '10' },
-								{ label: __('20 Seconds'), value: '20' },
-								{ label: __('30 Seconds'), value: '30' },
-								{ label: __('1 Minute'), value: '60' },
-								{ label: __('2 Minutes'), value: '120' },
-								{ label: __('3 Minutes'), value: '180' },
-								{ label: __('4 Minutes'), value: '240' },
-								{ label: __('5 Minutes'), value: '300' },
-								{ label: __('10 Minutes'), value: '600' },
-								{ label: __('15 Minutes'), value: '900' },
-								{ label: __('20 Minutes'), value: '1200' },
-								{ label: __('30 Minutes'), value: '1800' },
-								{ label: __('1 Hour'), value: '3600' },
-								{ label: __('2 Hours'), value: '7200' },
-								{ label: __('3 Hours'), value: '10800' },
-								{ label: __('4 Hours'), value: '14400' },
-								{ label: __('6 Hours'), value: '21600' },
-								{ label: __('8 Hours'), value: '28800' },
-								{ label: __('12 Hours'), value: '43200' },
-								{ label: __('1 Day'), value: '86400' },
-							]}
-							onChange={update('resolution')}
-						/>
 						<NumberControl
 							label={__('Top X')}
 							value={topX}
@@ -206,12 +179,40 @@ export default function Edit( { attributes, setAttributes } ) {
 							isShiftStepEnabled={true}
 							shiftStep={1}
 						/>
-
 						<ToggleControl
 							label={__('Summarize')}
 							checked={summarize}
 							onChange={update('summarize')}
 						/>
+						{ ! summarize && (
+							<SelectControl
+								label={__('Resolution')}
+								value={resolution}
+								options={[
+									{ label: __('10 Seconds'), value: '10' },
+									{ label: __('20 Seconds'), value: '20' },
+									{ label: __('30 Seconds'), value: '30' },
+									{ label: __('1 Minute'), value: '60' },
+									{ label: __('2 Minutes'), value: '120' },
+									{ label: __('3 Minutes'), value: '180' },
+									{ label: __('4 Minutes'), value: '240' },
+									{ label: __('5 Minutes'), value: '300' },
+									{ label: __('10 Minutes'), value: '600' },
+									{ label: __('15 Minutes'), value: '900' },
+									{ label: __('20 Minutes'), value: '1200' },
+									{ label: __('30 Minutes'), value: '1800' },
+									{ label: __('1 Hour'), value: '3600' },
+									{ label: __('2 Hours'), value: '7200' },
+									{ label: __('3 Hours'), value: '10800' },
+									{ label: __('4 Hours'), value: '14400' },
+									{ label: __('6 Hours'), value: '21600' },
+									{ label: __('8 Hours'), value: '28800' },
+									{ label: __('12 Hours'), value: '43200' },
+									{ label: __('1 Day'), value: '86400' },
+								]}
+								onChange={update('resolution')}
+							/>
+						) }
 					</>)}
 
 			</PanelBody>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -189,6 +189,7 @@ export default function Edit( { attributes, setAttributes } ) {
 								label={__('Resolution')}
 								value={resolution}
 								options={[
+									{ label: __('auto'), value: '' },
 									{ label: __('10 Seconds'), value: '10' },
 									{ label: __('20 Seconds'), value: '20' },
 									{ label: __('30 Seconds'), value: '30' },

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -31,7 +31,7 @@ import FilterBuilder from './components/lib/filterBuilder';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters, predefinedFilters, allowFrontendFilters } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, predefinedFilters, allowFrontendFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -160,8 +160,8 @@ export default function Edit( { attributes, setAttributes } ) {
 				<ToggleControl
 					label={ __( 'Enable Filter Controls' ) }
 					help={ __( 'Allow users to view and interact with filters on the frontend. See the `Predefined Filters` section below to add default filters' ) }
-					checked={ showFilters }
-					onChange={ update('showFilters') }
+					checked={ allowFrontendFilters }
+					onChange={ update('allowFrontendFilters') }
 				/>
 			</PanelBody>
 			<PanelBody title={__('Graph Data')}>
@@ -237,22 +237,11 @@ export default function Edit( { attributes, setAttributes } ) {
 				/>
 			</PanelBody>
 
-			{showFilters && (
-				<>
-					<PanelBody title={__('Filter Settings')}>
-						<ToggleControl
-							label={ __( 'Allow Frontend Filter Building' ) }
-							help={ __( 'Enable users to add and remove filters on the frontend' ) }
-							checked={ allowFrontendFilters }
-							onChange={ update('allowFrontendFilters') }
-						/>
-					</PanelBody>
-
-					<FilterBuilder
-						filters={predefinedFilters}
-						onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
-					/>
-				</>
+			{allowFrontendFilters && (
+				<FilterBuilder
+					filters={predefinedFilters}
+					onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+				/>
 			)}
 		</InspectorControls>
 	)

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$summarize = $params['summarize'] ?? false;
 
 				$options = array(
-					'max_bucket_size'      => $params['top_x'] ?? 20, // Metrics API has top_x as max_bucket_size.
+					'top_x'      => $params['top_x'] ?? 20,
 					'resolution' => $params['resolution'] ?? 10,
 				);
 
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 					if ( json_last_error() !== JSON_ERROR_NONE ) {
 						return new WP_REST_Response( esc_html__( 'Invalid filters', 'wpcloud' ), 400 );
 					}
-					$options['filters'] = $filters;
+					$options['filters'] = $this->convert_filters_format( $filters );
 				}
 
 				$site_id = $params['site_id'] ?? null;
@@ -289,6 +289,42 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				return new WP_Error( 'rest_invalid_param', wp_sprintf( esc_html__( 'Invalid %s time', 'wpcloud' ), $position ), array( 'status' => 400 ) );
 			}
 			return $ts;
+		}
+
+		/**
+		 * Convert filters from array format to object format.
+		 *
+		 * @param array $filters The filters in array format.
+		 * @return array The filters in object format.
+		 */
+		public function convert_filters_format( array $filters ): array {
+			$converted_filters = array();
+
+			foreach ( $filters as $filter ) {
+				if ( ! is_array( $filter ) || count( $filter ) < 3 ) {
+					// Skip invalid filters.
+					wpcloud_l( 'Invalid filter format', $filter );
+					continue;
+				}
+				$value = $filter[2];
+
+				$filter_object = array(
+					'column'   => $filter[0],
+					'operator' => $filter[1],
+					'value'    => $value,
+				);
+
+				// Check if the value contains commas, indicating multiple values.
+				if ( strpos( $value, ',' ) !== false ) {
+					// Split the value by commas and trim whitespace.
+					$values                 = array_map( 'trim', explode( ',', $value ) );
+					$filter_object['value'] = $values;
+				}
+
+				$converted_filters[] = $filter_object;
+			}
+
+			return $converted_filters;
 		}
 
 		/**

--- a/plugin/includes/class-wpcloud-metric-data-view.php
+++ b/plugin/includes/class-wpcloud-metric-data-view.php
@@ -53,7 +53,7 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 			return new WP_Error( 'invalid_metric', 'Invalid metric', array( 'status' => 400 ) );
 		}
 
-		if ( ! array_key_exists( $this->dimension, $this->get_available_dimensions() ) ) {
+		if ( ! array_key_exists( $this->dimension, $this->get_available_dimensions( $this->metric ) ) ) {
 			return new WP_Error( 'invalid_dimension', 'Invalid dimension', array( 'status' => 400 ) );
 		}
 

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -163,20 +163,99 @@ class WPCloud_Metrics {
 	 */
 	public static function get_available_metrics(): array {
 		return array(
+			// Edge Request Logs
 			'requests'                   => __( 'Requests', 'wpcloud' ),
 			'requests_persec'            => __( 'Requests per second', 'wpcloud' ),
 			'response_bytes'             => __( 'Response bytes', 'wpcloud' ),
 			'response_bytes_persec'      => __( 'Response bytes per second', 'wpcloud' ),
 			'response_bytes_average'     => __( 'Response bytes average', 'wpcloud' ),
 			'response_time_average'      => __( 'Response time average', 'wpcloud' ),
-			'php_response_time_sum'      => __( 'PHP response time sum', 'wpcloud' ),
+			'php_response_time_sum'      => __( 'PHP response time (sum)', 'wpcloud' ),
+
+			/* Available but better as a dimension */
 			'edge_cache_hit_percentage'  => __( 'Edge cache hit percentage', 'wpcloud' ),
 			'edge_cache_miss_percentage' => __( 'Edge cache miss percentage', 'wpcloud' ),
+
+			// PHP-FPM Origin Logs
 			'php_cpu_time'               => __( 'PHP CPU time', 'wpcloud' ),
 			'php_cpu_time_persec'        => __( 'PHP CPU time per second', 'wpcloud' ),
 			'php_response_time'          => __( 'PHP response time', 'wpcloud' ),
 			'php_requests'               => __( 'PHP requests', 'wpcloud' ),
 			'php_requests_persec'        => __( 'PHP requests per second', 'wpcloud' ),
+			'php_workers_average'        => __( 'PHP workers_average', 'wpcloud' ),
+			'php_workers_min'            => __( 'PHP workers min', 'wpcloud' ),
+			'php_workers_max'			 => __( 'PHP workers max', 'wpcloud' ),
+
+			/* Available but better as a dimension
+			'php_requests_burst_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			'php_requests_limited_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			'php_requests_normal_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			*/
+
+			// Edge based Unique Views
+			'uniques'					=> __( 'Unique Visits', 'wpcloud' ),
+			'views'						=> __( 'Page Views', 'wpcloud' ),
+
+			// MySQL Pool Stats
+			/* Available but does it make sense to share pool info with clients?
+			'mysql_pool_replication_lag_average' => __( 'MySQL Replication Lag', 'wpcloud' ),
+			*/
+
+			// cgroup User Stats
+			'cgroup_cpu_usage' => __( 'CPU Usage', 'wpcloud' ),
+			'cgroup_cpu_usage_persec' => __( 'CPU Usage per second', 'wpcloud' ),
+
+			// MySQL / MariaDB User Stats
+			// @todo We might want to simplify the list to most used :)
+			'mysql_total_connections' => __( 'MYSQL total connections', 'wpcloud' ),
+			'mysql_total_connections_persec' => __( 'MYSQL total connections per second', 'wpcloud' ),
+			'mysql_concurrent_connections' => __( 'MYSQL concurrent connections', 'wpcloud' ),
+			'mysql_concurrent_connections_persec' => __( 'MYSQL concurrent connections per second', 'wpcloud' ),
+			'mysql_connected_time' => __( 'MYSQL connected time', 'wpcloud' ),
+			'mysql_connected_time_persec' => __( 'MYSQL connected time per second', 'wpcloud' ),
+			'mysql_busy_time' => __( 'MYSQL busy time', 'wpcloud' ),
+			'mysql_busy_time_persec' => __( 'MYSQL busy time per second', 'wpcloud' ),
+			'mysql_cpu_time' => __( 'MYSQL cpu time', 'wpcloud' ),
+			'mysql_cpu_time_persec' => __( 'MYSQL cpu time per second', 'wpcloud' ),
+			'mysql_bytes_received' => __( 'MYSQL bytes received', 'wpcloud' ),
+			'mysql_bytes_received_persec' => __( 'MYSQL bytes received per second', 'wpcloud' ),
+			'mysql_bytes_sent' => __( 'MYSQL bytes sent', 'wpcloud' ),
+			'mysql_bytes_sent_persec' => __( 'MYSQL bytes sent', 'wpcloud' ),
+			'mysql_binlog_bytes_written' => __( 'MYSQL binlog bytes written', 'wpcloud' ),
+			'mysql_binlog_bytes_written_persec' => __( 'MYSQL binlog bytes written per second', 'wpcloud' ),
+			'mysql_rows_read' => __( 'MYSQL rows read', 'wpcloud' ),
+			'mysql_rows_read_persec' => __( 'MYSQL rows read per second', 'wpcloud' ),
+			'mysql_rows_sent' => __( 'MYSQL rows sent', 'wpcloud' ),
+			'mysql_rows_sent_persec' => __( 'MYSQL rows sent per second', 'wpcloud' ),
+			'mysql_rows_deleted' => __( 'MYSQL rows deleted', 'wpcloud' ),
+			'mysql_rows_deleted_persec' => __( 'MYSQL rows deleted per second', 'wpcloud' ),
+			'mysql_rows_inserted' => __( 'MYSQL rows inserted', 'wpcloud' ),
+			'mysql_rows_inserted_persec' => __( 'MYSQL rows inserted per second', 'wpcloud' ),
+			'mysql_rows_updated' => __( 'MYSQL rows updated', 'wpcloud' ),
+			'mysql_rows_updated_persec' => __( 'MYSQL rows updated per second', 'wpcloud' ),
+			'mysql_select_commands' => __( 'MYSQL select commands', 'wpcloud' ),
+			'mysql_select_commands_persec' => __( 'MYSQL select commands per second', 'wpcloud' ),
+			'mysql_update_commands' => __( 'MYSQL update commands', 'wpcloud' ),
+			'mysql_update_commands_persec' => __( 'MYSQL update commands per second', 'wpcloud' ),
+			'mysql_other_commands' => __( 'MYSQL other commands', 'wpcloud' ),
+			'mysql_other_commands_persec' => __( 'MYSQL other commands per second', 'wpcloud' ),
+			'mysql_commit_transactions' => __( 'MYSQL commit transactions', 'wpcloud' ),
+			'mysql_commit_transactions_persec' => __( 'MYSQL commit transactions per second', 'wpcloud' ),
+			'mysql_rollback_transactions' => __( 'MYSQL rollback transactions', 'wpcloud' ),
+			'mysql_rollback_transactions_persec' => __( 'MYSQL rollback transactions per second', 'wpcloud' ),
+			'mysql_denied_connections' => __( 'MYSQL denied connections', 'wpcloud' ),
+			'mysql_denied_connections_persec' => __( 'MYSQL denied connections per second', 'wpcloud' ),
+			'mysql_lost_connections' => __( 'MYSQL lost connections', 'wpcloud' ),
+			'mysql_lost_connections_persec' => __( 'MYSQL lost connections per second', 'wpcloud' ),
+			'mysql_access_denied' => __( 'MYSQL access denied', 'wpcloud' ),
+			'mysql_access_denied_persec' => __( 'MYSQL access denied per second', 'wpcloud' ),
+			'mysql_empty_queries' => __( 'MYSQL empty queries', 'wpcloud' ),
+			'mysql_empty_queries_persec' => __( 'MYSQL empty queries per second', 'wpcloud' ),
+			'mysql_total_ssl_connections' => __( 'MYSQL total ssl connections', 'wpcloud' ),
+			'mysql_total_ssl_connections_persec' => __( 'MYSQL total ssl connections per second', 'wpcloud' ),
+			'mysql_max_statement_time_exceeded' => __( 'MYSQL max statement time exceeded', 'wpcloud' ),
+			'mysql_max_statement_time_exceeded_persec' => __( 'MYSQL max statement time exceeded per second', 'wpcloud' ),
+
 		);
 	}
 
@@ -185,39 +264,71 @@ class WPCloud_Metrics {
 	 *
 	 * @return array The dimensions.
 	 */
-	public static function get_available_dimensions(): array {
-		return array(
-			'http_version'         => __( 'HTTP version', 'wpcloud' ),
-			'server_protocol'      => __( 'Server protocol', 'wpcloud' ),
-			'http_verb'            => __( 'HTTP verb', 'wpcloud' ),
-			'request_method'       => __( 'Request method', 'wpcloud' ),
-			'http_host'            => __( 'HTTP host', 'wpcloud' ),
-			'http_status'          => __( 'HTTP status', 'wpcloud' ),
-			'page_renderer'        => __( 'Page renderer', 'wpcloud' ),
-			'request_renderer'     => __( 'Request renderer', 'wpcloud' ),
-			'page_is_cached'       => __( 'Page is cached', 'wpcloud' ),
-			'is_upstream_cached'   => __( 'Is upstream cached', 'wpcloud' ),
-			'wp_admin_ajax_action' => __( 'WP admin AJAX action', 'wpcloud' ),
-			'visitor_asn'          => __( 'Visitor ASN', 'wpcloud' ),
-			'asn'                  => __( 'ASN', 'wpcloud' ),
-			'visitor_country_code' => __( 'Visitor country code', 'wpcloud' ),
-			'country_code'         => __( 'Country code', 'wpcloud' ),
-			'visitor_is_crawler'   => __( 'Visitor is crawler', 'wpcloud' ),
-			'is_crawler'           => __( 'Is crawler', 'wpcloud' ),
-			'visitor_device_type'  => __( 'Visitor device type', 'wpcloud' ),
-			'edge_cache_status'    => __( 'Edge cache status', 'wpcloud' ),
-			'is_rate_limited'      => __( 'Is rate limited', 'wpcloud' ),
-			'rate_limit_reason'    => __( 'Rate limit reason', 'wpcloud' ),
-			'datacenter'           => __( 'Datacenter', 'wpcloud' ),
-			'path'                 => __( 'Path', 'wpcloud' ),
-			'atomic_site_id'       => __( 'Atomic site ID', 'wpcloud' ),
-			'proxy_type'           => __( 'Proxy type', 'wpcloud' ),
-			/**
-			 * Planned
-			 * 'remote_address'      => __( 'Remote address', 'wpcloud' ),
-			 * 'http_user_agent'     => __( 'HTTP user agent', 'wpcloud' ),
-			 * 'http_referer'        => __( 'HTTP referer', 'wpcloud' ),
-			*/
-		);
+	public static function get_available_dimensions( $metric = null ): array {
+		if( ! empty( $metric ) && str_starts_with( $metric, 'mysql_pool_' ) ) {
+			// MySQL Pool Stats Dimensions
+			return array(
+				'pool'	 => __( 'Pool Server ID', 'wpcloud' ),
+				'server' => __( 'Pool Server Name', 'wpcloud' ),
+			);
+		} else if( ! empty( $metric ) && str_starts_with( $metric, 'mysql_' ) ) {
+			// MySQL User Stats Dimensions
+			return array(
+				'pool'				=> __( 'Pool Server ID', 'wpcloud' ),
+				'server' 			=> __( 'Pool Server Name', 'wpcloud' ),
+				'atomic_site_id'	=> __( 'Atomic site ID', 'wpcloud' ),
+			);
+		} else if( ! empty( $metric ) && str_starts_with( $metric, 'cgroup_' ) ) {
+			// cgroup User Stats Dimensions
+			return array(
+				'pool'				=> __( 'Pool Server ID', 'wpcloud' ),
+				'server' 			=> __( 'Pool Server Name', 'wpcloud' ),
+				'atomic_site_id'	=> __( 'Atomic site ID', 'wpcloud' ),
+			);
+		} else if( in_array( $metric, Array( 'uniques', 'views' ), true ) ) {
+			// Uniques and Views Dimensions
+			return array(
+				'hostname' => __('hostname', 'wpcloud'),
+			);
+		} else if(
+			! empty( $metric )
+			&& str_starts_with( $metric, 'php_' )
+			&& ! in_array( $metric, Array( 'php_response_time_sum' ), true ) ) {
+			// PHP-FPM Origin Dimensions
+			return array(
+				'http_verb'				=> __( 'HTTP Verb', 'wpcloud' ),
+				'http_host' 			=> __( 'HTTP Host', 'wpcloud' ),
+				'datacenter'			=> __( 'Datacenter', 'wpcloud' ),
+				'atomic_site_id'		=> __( 'Site ID', 'wpcloud' ),
+				'burst_status'			=> __( 'Burst Status', 'wpcloud' ),
+			);
+		} else {
+			// Edge Dimensions // Use for Default
+			return array(
+				'server_protocol'      => __( 'Server protocol', 'wpcloud' ),
+				'request_method'       => __( 'Request method', 'wpcloud' ),
+				'http_host'            => __( 'HTTP host', 'wpcloud' ),
+				'http_status'          => __( 'HTTP status', 'wpcloud' ),
+				'http_user_agent'      => __( 'HTTP User Agent', 'wpcloud' ),
+				'http_referer'         => __( 'HTTP referer', 'wpcloud' ),
+				'request_renderer'     => __( 'Request renderer', 'wpcloud' ),
+				'is_upstream_cached'   => __( 'Is upstream cached', 'wpcloud' ),
+				'wp_admin_ajax_action' => __( 'WP Admin AJAX action', 'wpcloud' ),
+				'visitor_asn'          => __( 'Visitor ASN', 'wpcloud' ),
+				'visitor_country_code' => __( 'Visitor country code', 'wpcloud' ),
+				'visitor_is_crawler'   => __( 'Visitor is crawler', 'wpcloud' ),
+				'visitor_device_type'  => __( 'Visitor device type', 'wpcloud' ),
+				'visitor_is_logged_in' => __( 'Visitor is logged In', 'wpcloud' ),
+				'visitor_os'           => __( 'Visitor OS', 'wpcloud' ),
+				'visitor_browser'      => __( 'Visitor Browser', 'wpcloud' ),
+				'edge_cache_status'    => __( 'Edge cache status', 'wpcloud' ),
+				'is_rate_limited'      => __( 'Is rate limited', 'wpcloud' ),
+				'rate_limit_reason'    => __( 'Rate limit reason', 'wpcloud' ),
+				'datacenter'           => __( 'Datacenter', 'wpcloud' ),
+				'path'                 => __( 'Path', 'wpcloud' ),
+				'atomic_site_id'       => __( 'Atomic site ID', 'wpcloud' ),
+				'proxy_type'           => __( 'Proxy type', 'wpcloud' ),
+			);
+		}
 	}
 }

--- a/plugin/tests/js/components/graph/graph.test.js
+++ b/plugin/tests/js/components/graph/graph.test.js
@@ -11,6 +11,19 @@ import Graph from '../../../../blocks/src/components/graph/components/graph';
 import stationApi from '@wpcloud/utils/api';
 import { ApiContext } from '@wpcloud/metrics/components/apiContext';
 
+// Mock the WordPress components
+jest.mock('@wordpress/components', () => ({
+    Flex: ({ children }) => <div className="mock-flex">{children}</div>,
+    FlexItem: ({ children }) => <div className="mock-flex-item">{children}</div>,
+    Spinner: () => <div className="mock-spinner">Loading...</div>,
+}));
+
+// Mock the WordPress icons
+jest.mock('@wordpress/icons', () => ({
+    Icon: ({ icon }) => <span className="mock-icon">{icon}</span>,
+    trash: 'trash-icon',
+}));
+
 // Mock the stationApi.get method
 jest.mock('@wpcloud/utils/api', () => ({
     get: jest.fn(),


### PR DESCRIPTION
The available Metrics from WP Cloud come from multiple sources that allow slicing by different dimensions. It should not be on users to know the mappings. 

This update includes 2 modificaitons as outlined in https://github.com/Automattic/wpcloud-station/issues/320
1) Updates the available metrics/dimensions to align with current options from the Atomic API

2) adds logic so that when editing a Graph the dimension options update to reflect available options for the selected metric. If the existing dimension value is not a valid option it resets to the first option in current set.

Note that We could update the JSON Endpoint to have the mapping logic in the response however I elected to have the map directly in the JavaScript element as I didn't want to mess around with the structure :) Feel free to suggest edits.

<img width="295" alt="Screenshot 2025-04-23 at 2 46 06 PM" src="https://github.com/user-attachments/assets/1943a924-d431-4112-b390-df6ff5f68935" />
