### PR TITLE
Update/summarize resolution dependency

### DIFF
--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -43,10 +43,6 @@ export default function Edit( { attributes, setAttributes } ) {
 		fetchAvailable();
 	}, []);
 
-	useEffect( () => {
-
-	}, [summarize] )
-
 	const controls = (
 		<InspectorControls>
 			<PanelBody title={__('Graph Settings')}>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -43,6 +43,10 @@ export default function Edit( { attributes, setAttributes } ) {
 		fetchAvailable();
 	}, []);
 
+	useEffect( () => {
+
+	}, [summarize] )
+
 	const controls = (
 		<InspectorControls>
 			<PanelBody title={__('Graph Settings')}>
@@ -93,33 +97,6 @@ export default function Edit( { attributes, setAttributes } ) {
 							options={Object.keys(dimensions).map((key) => ({ label: dimensions[key], value: key })) }
 							onChange={update('dimension')}
 						/>
-						<SelectControl
-							label={__('Resolution')}
-							value={resolution}
-							options={[
-								{ label: __('10 Seconds'), value: '10' },
-								{ label: __('20 Seconds'), value: '20' },
-								{ label: __('30 Seconds'), value: '30' },
-								{ label: __('1 Minute'), value: '60' },
-								{ label: __('2 Minutes'), value: '120' },
-								{ label: __('3 Minutes'), value: '180' },
-								{ label: __('4 Minutes'), value: '240' },
-								{ label: __('5 Minutes'), value: '300' },
-								{ label: __('10 Minutes'), value: '600' },
-								{ label: __('15 Minutes'), value: '900' },
-								{ label: __('20 Minutes'), value: '1200' },
-								{ label: __('30 Minutes'), value: '1800' },
-								{ label: __('1 Hour'), value: '3600' },
-								{ label: __('2 Hours'), value: '7200' },
-								{ label: __('3 Hours'), value: '10800' },
-								{ label: __('4 Hours'), value: '14400' },
-								{ label: __('6 Hours'), value: '21600' },
-								{ label: __('8 Hours'), value: '28800' },
-								{ label: __('12 Hours'), value: '43200' },
-								{ label: __('1 Day'), value: '86400' },
-							]}
-							onChange={update('resolution')}
-						/>
 						<NumberControl
 							label={__('Top X')}
 							value={topX}
@@ -130,12 +107,40 @@ export default function Edit( { attributes, setAttributes } ) {
 							isShiftStepEnabled={true}
 							shiftStep={1}
 						/>
-
 						<ToggleControl
 							label={__('Summarize')}
 							checked={summarize}
 							onChange={update('summarize')}
 						/>
+						{ ! summarize && (
+							<SelectControl
+								label={__('Resolution')}
+								value={resolution}
+								options={[
+									{ label: __('10 Seconds'), value: '10' },
+									{ label: __('20 Seconds'), value: '20' },
+									{ label: __('30 Seconds'), value: '30' },
+									{ label: __('1 Minute'), value: '60' },
+									{ label: __('2 Minutes'), value: '120' },
+									{ label: __('3 Minutes'), value: '180' },
+									{ label: __('4 Minutes'), value: '240' },
+									{ label: __('5 Minutes'), value: '300' },
+									{ label: __('10 Minutes'), value: '600' },
+									{ label: __('15 Minutes'), value: '900' },
+									{ label: __('20 Minutes'), value: '1200' },
+									{ label: __('30 Minutes'), value: '1800' },
+									{ label: __('1 Hour'), value: '3600' },
+									{ label: __('2 Hours'), value: '7200' },
+									{ label: __('3 Hours'), value: '10800' },
+									{ label: __('4 Hours'), value: '14400' },
+									{ label: __('6 Hours'), value: '21600' },
+									{ label: __('8 Hours'), value: '28800' },
+									{ label: __('12 Hours'), value: '43200' },
+									{ label: __('1 Day'), value: '86400' },
+								]}
+								onChange={update('resolution')}
+							/>
+						) }
 					</>)}
 
 			</PanelBody>


### PR DESCRIPTION
As outlined in https://github.com/Automattic/wpcloud-station/issues/318 resolution has no function if summarize is chosen. This adds logic so that if summarize is true the resolution UX control in the editor is hidden. 

<img width="281" alt="Screenshot 2025-04-23 at 3 07 13 PM" src="https://github.com/user-attachments/assets/d4c4ff71-0f3b-4778-873f-d47b79de5263" />
<img width="279" alt="Screenshot 2025-04-23 at 3 07 19 PM" src="https://github.com/user-attachments/assets/3f1f9f2c-3b08-4fd8-bb6d-828e5d65a832" />
