### PR TITLE
Graph Block : Add auto resolution option

### DIFF
--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -113,6 +113,7 @@ export default function Edit( { attributes, setAttributes } ) {
 								label={__('Resolution')}
 								value={resolution}
 								options={[
+									{ label: __('auto'), value: '' },
 									{ label: __('10 Seconds'), value: '10' },
 									{ label: __('20 Seconds'), value: '20' },
 									{ label: __('30 Seconds'), value: '30' },


### PR DESCRIPTION
Resolution is more of an advanced feature. It works as more of a "Desired" Option in that if there would be too many buckets for that resolution we'll use a different resolution. As such we are adding auto as the default ux option to communicate a default behavior of sizing to finest resolution allowed for given time period. 

<img width="286" alt="Screenshot 2025-04-23 at 3 27 22 PM" src="https://github.com/user-attachments/assets/25137667-6b88-4a05-81cf-6991f5e7bf80" />


As requested in https://github.com/Automattic/wpcloud-station/issues/317