### PR TITLE
Metrics: Graph filters

### DIFF
--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -91,6 +91,10 @@
 		"minWidth" : {
 			"type" : "string",
 			"default" : "500px"
+		},
+		"showFilters" : {
+			"type" : "boolean",
+			"default" : true
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -119,16 +119,24 @@ export default function Graph( props ) {
 	//
 	// Handle filter updates
 	const handleFiltersUpdate = ({ filters: newFilters }) => {
-		setFilters(newFilters.map(filter => ({
-			enabled: true,
-			value: {
-				field: filter[0],
-				operator: filter[1],
-				value: filter[2]
-			},
-			compact: `${filter[0]} ${filter[1]} ${filter[2]}`,
-			label: `${filter[0]} ${filter[1]} ${filter[2]}`
-		})));
+		setFilters(newFilters.map(filter => {
+			// Ensure values are properly handled
+			const field = filter[0];
+			const operator = filter[1];
+			const value = filter[2];
+			const valueStr = String(value);
+
+			return {
+				enabled: true,
+				value: {
+					field,
+					operator,
+					value
+				},
+				compact: `${field} ${operator} ${valueStr}`,
+				label: `${field} ${operator} ${valueStr}`
+			};
+		}));
 	};
 
 	return (

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -19,6 +19,7 @@ import Overlay from './overlay';
 import useGraphOptions from './lib/useGraphOptions';
 import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
+import Filters from './lib/filters';
 
 export default function Graph( props ) {
 
@@ -52,9 +53,17 @@ export default function Graph( props ) {
 	const [ series, setSeries ] = useState([]);
 	const [ meta, setMeta ] = useState({});
 	const [ loading, setLoading ] = useState( true );
+	const [ filters, setFilters ] = useState([]);
 
 	const containerRef = useRef(null);
-	const style = { position: "relative", minWidth, minHeight: '500px', ...styles };
+	// Ensure the container takes full width of parent and has appropriate minimum dimensions
+	const style = {
+		position: "relative",
+		width: '100%',
+		minWidth,
+		minHeight: '500px',
+		...styles
+	};
 	// if the className does not contain has-background add a background color
 	if ( ! className.includes( 'has-background' ) ) {
 		styles.backgroundColor = 'white';
@@ -66,6 +75,9 @@ export default function Graph( props ) {
 		setLoading(true);
 		async function fetchData() {
 			try {
+				// Extract active filters for the API query
+				const activeFilters = filters.filter(f => f.enabled).map(f => [f.value.field, f.value.operator, f.value.value]);
+
 				const { data, series, meta } = await stationApi.get( `${apiPath}/${metric}`, {
 					query: {
 						start,
@@ -74,6 +86,7 @@ export default function Graph( props ) {
 						resolution,
 						summarize,
 						top_x: topX,
+						filters: activeFilters.length > 0 ? activeFilters : undefined,
 					}, parse: true, signal
 				});
 				setData(data);
@@ -89,7 +102,7 @@ export default function Graph( props ) {
 
 		fetchData();
 		return () => controller.abort();
-	}, [ apiPath, start, end, refresh ] );
+	}, [ apiPath, start, end, refresh, filters ] );
 
 
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type, orientation });
@@ -104,10 +117,33 @@ export default function Graph( props ) {
 
 	const showOverlay = loading || !hasData;
 	//
+	// Handle filter updates
+	const handleFiltersUpdate = ({ filters: newFilters }) => {
+		setFilters(newFilters.map(filter => ({
+			enabled: true,
+			value: {
+				field: filter[0],
+				operator: filter[1],
+				value: filter[2]
+			},
+			compact: `${filter[0]} ${filter[1]} ${filter[2]}`,
+			label: `${filter[0]} ${filter[1]} ${filter[2]}`
+		})));
+	};
+
 	return (
-		<div ref={containerRef} className={className} style={style}>
+		<div style={{ width: '100%' }}>
+			<div ref={containerRef} className={className} style={style}>
 			{showOverlay && <Overlay loading={loading} title={title} /> }
 			{ hasData && <UplotReact options={options} data={d} /> }
+			</div>
+			<div style={{ position: 'relative', marginTop: '10px', zIndex: 1 }}>
+				<Filters
+					filters={filters}
+					onFiltersUpdate={handleFiltersUpdate}
+					loading={loading}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -21,6 +21,78 @@ import stationApi from '@wpcloud/utils/api';
 import { useApiContext } from '@wpcloud/metrics/components/apiContext';
 import Filters from './lib/filters';
 
+/**
+ * Parse URL parameters to get filters for a specific graph
+ *
+ * @param {string} graphId - The unique ID of the graph
+ * @returns {Array} - Array of filter objects
+ */
+const getFiltersFromUrl = (graphId) => {
+	try {
+		// Get the URL search parameters
+		const urlParams = new URLSearchParams(window.location.search);
+
+		// Look specifically for the parameter with this graph's ID
+		const paramName = `filters_${graphId}`;
+		const filterParam = urlParams.get(paramName);
+
+		// If there's no parameter specifically for this graph, return empty array
+		if (!filterParam) {
+			return [];
+		}
+
+		// Parse the JSON string from the URL
+		const decodedFilters = JSON.parse(decodeURIComponent(filterParam));
+
+		// Convert the array format to the filter object format
+		return decodedFilters.map(filter => ({
+			enabled: true,
+			value: {
+				field: filter[0],
+				operator: filter[1],
+				value: filter[2]
+			},
+			compact: `${filter[0]} ${filter[1]} ${filter[2]}`,
+			label: `${filter[0]} ${filter[1]} ${filter[2]}`
+		}));
+	} catch (error) {
+		console.error('Error parsing filters from URL:', error);
+		return [];
+	}
+};
+
+/**
+ * Update URL parameters with filters for a specific graph
+ *
+ * @param {string} graphId - The unique ID of the graph
+ * @param {Array} filters - Array of filter objects
+ */
+const updateUrlWithFilters = (graphId, filters) => {
+	try {
+		// Get the active filters in array format
+		const activeFilters = filters
+			.filter(f => f.enabled)
+			.map(f => [f.value.field, f.value.operator, String(f.value.value)]);
+
+		// Get the current URL search parameters
+		const urlParams = new URLSearchParams(window.location.search);
+
+		// If there are active filters, add them to the URL
+		if (activeFilters.length > 0) {
+			urlParams.set(`filters_${graphId}`, encodeURIComponent(JSON.stringify(activeFilters)));
+		} else {
+			// If there are no active filters, remove the parameter
+			urlParams.delete(`filters_${graphId}`);
+		}
+
+		// Update the URL without reloading the page
+		const newUrl = `${window.location.pathname}?${urlParams.toString()}${window.location.hash}`;
+		window.history.replaceState({}, '', newUrl);
+	} catch (error) {
+		console.error('Error updating URL with filters:', error);
+	}
+};
+
 export default function Graph( props ) {
 
 	const {
@@ -43,9 +115,31 @@ export default function Graph( props ) {
 		orientation,
 
 		// Dynamic metric props.
-		interval, refresh
+		interval, refresh,
+
+		// Unique identifier for this graph
+		id = `graph-${metric}-${dimension}`
 
 	} = props;
+
+	// Create a deterministic ID based on the graph's properties
+	// This will be the same across page loads for the same graph
+	const generateStableId = (metric, dimension, title) => {
+		// Create a string that uniquely identifies this graph
+		const baseString = `${metric}-${dimension}-${title}`;
+		// Simple hash function to generate a numeric hash
+		let hash = 0;
+		for (let i = 0; i < baseString.length; i++) {
+			const char = baseString.charCodeAt(i);
+			hash = ((hash << 5) - hash) + char;
+			hash = hash & hash; // Convert to 32bit integer
+		}
+		// Convert to a positive number and return
+		return `${id.replace(/[^a-zA-Z0-9-_]/g, '-')}-${Math.abs(hash)}`;
+	};
+
+	// Generate a stable ID that will be the same across page loads
+	const graphId = generateStableId(metric, dimension, title);
 
 	const { apiPath } = useApiContext();
 	const { start, end } = interval || {};
@@ -53,7 +147,15 @@ export default function Graph( props ) {
 	const [ series, setSeries ] = useState([]);
 	const [ meta, setMeta ] = useState({});
 	const [ loading, setLoading ] = useState( true );
-	const [ filters, setFilters ] = useState([]);
+	// Initialize filters from URL parameters if available
+	const [ filters, setFilters ] = useState(() => {
+		// Only run in browser environment
+		if (typeof window !== 'undefined') {
+			const urlFilters = getFiltersFromUrl(graphId);
+			return urlFilters.length > 0 ? urlFilters : [];
+		}
+		return [];
+	});
 
 	const containerRef = useRef(null);
 	// Ensure the container takes full width of parent and has appropriate minimum dimensions
@@ -137,7 +239,7 @@ export default function Graph( props ) {
 	//
 	// Handle filter updates
 	const handleFiltersUpdate = ({ filters: newFilters }) => {
-		setFilters(newFilters.map(filter => {
+		const processedFilters = newFilters.map(filter => {
 			// Handle both array format [field, operator, value] and object format {field, operator, value}
 			let field, operator, value;
 
@@ -166,11 +268,17 @@ export default function Graph( props ) {
 				compact: `${field} ${operator} ${valueStr}`,
 				label: `${field} ${operator} ${valueStr}`
 			};
-		}));
+		});
+
+		// Update the state with the new filters
+		setFilters(processedFilters);
+
+		// Update the URL with the new filters
+		updateUrlWithFilters(graphId, processedFilters);
 	};
 
 	return (
-		<div style={{ width: '100%' }}>
+		<div style={{ width: '100%' }} data-graph-id={graphId}>
 			<div ref={containerRef} className={className} style={style}>
 			{showOverlay && <Overlay loading={loading} title={title} /> }
 			{ hasData && <UplotReact options={options} data={d} /> }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -118,7 +118,10 @@ export default function Graph( props ) {
 		interval, refresh,
 
 		// Unique identifier for this graph
-		id = `graph-${metric}-${dimension}`
+		id = `graph-${metric}-${dimension}`,
+
+		// Show filters toggle
+		showFilters = true
 
 	} = props;
 
@@ -283,13 +286,15 @@ export default function Graph( props ) {
 			{showOverlay && <Overlay loading={loading} title={title} /> }
 			{ hasData && <UplotReact options={options} data={d} /> }
 			</div>
-			<div style={{ position: 'relative', marginTop: '10px', zIndex: 1 }}>
-				<Filters
-					filters={filters}
-					onFiltersUpdate={handleFiltersUpdate}
-					loading={loading}
-				/>
-			</div>
+			{showFilters && (
+				<div style={{ position: 'relative', marginTop: '10px', zIndex: 1 }}>
+					<Filters
+						filters={filters}
+						onFiltersUpdate={handleFiltersUpdate}
+						loading={loading}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -78,16 +78,26 @@ export default function Graph( props ) {
 				// Extract active filters for the API query
 				const activeFilters = filters.filter(f => f.enabled).map(f => [f.value.field, f.value.operator, f.value.value]);
 
+				// Create the query parameters
+				const queryParams = {
+					start,
+					end,
+					dimension,
+					resolution,
+					summarize,
+					top_x: topX,
+				};
+
+				// Only add filters if there are any active ones
+				// Stringify the filters array to ensure it's sent as a JSON array
+				if (activeFilters.length > 0) {
+					queryParams.filters = JSON.stringify(activeFilters);
+				}
+
 				const { data, series, meta } = await stationApi.get( `${apiPath}/${metric}`, {
-					query: {
-						start,
-						end,
-						dimension,
-						resolution,
-						summarize,
-						top_x: topX,
-						filters: activeFilters.length > 0 ? activeFilters : undefined,
-					}, parse: true, signal
+					query: queryParams,
+					parse: true,
+					signal
 				});
 				setData(data);
 				setSeries(series);
@@ -120,10 +130,22 @@ export default function Graph( props ) {
 	// Handle filter updates
 	const handleFiltersUpdate = ({ filters: newFilters }) => {
 		setFilters(newFilters.map(filter => {
-			// Ensure values are properly handled
-			const field = filter[0];
-			const operator = filter[1];
-			const value = filter[2];
+			// Handle both array format [field, operator, value] and object format {field, operator, value}
+			let field, operator, value;
+
+			if (Array.isArray(filter)) {
+				// Array format: [field, operator, value]
+				field = filter[0];
+				operator = filter[1];
+				value = filter[2];
+			} else {
+				// Object format: {field, operator, value}
+				field = filter.field;
+				operator = filter.operator;
+				value = filter.value;
+			}
+
+			// Convert value to string for display
 			const valueStr = String(value);
 
 			return {

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -151,14 +151,21 @@ export default function Graph( props ) {
 	const [ meta, setMeta ] = useState({});
 	const [ loading, setLoading ] = useState( true );
 	// Initialize filters from URL parameters if available
-	const [ filters, setFilters ] = useState(() => {
-		// Only run in browser environment
+	const [ filters, setFilters ] = useState([]);
+
+	// Load filters from URL on mount
+	useEffect(() => {
 		if (typeof window !== 'undefined') {
-			const urlFilters = getFiltersFromUrl(graphId);
-			return urlFilters.length > 0 ? urlFilters : [];
+			try {
+				const urlFilters = getFiltersFromUrl(graphId);
+				if (urlFilters && Array.isArray(urlFilters) && urlFilters.length > 0) {
+					setFilters(urlFilters);
+				}
+			} catch (error) {
+				console.error('Error initializing filters:', error);
+			}
 		}
-		return [];
-	});
+	}, [graphId]);
 
 	const containerRef = useRef(null);
 	// Ensure the container takes full width of parent and has appropriate minimum dimensions

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -75,8 +75,16 @@ export default function Graph( props ) {
 		setLoading(true);
 		async function fetchData() {
 			try {
-				// Extract active filters for the API query
-				const activeFilters = filters.filter(f => f.enabled).map(f => [f.value.field, f.value.operator, f.value.value]);
+				// Extract active filters for the API query and ensure values are strings
+				const activeFilters = filters.filter(f => f.enabled).map(f => {
+					// Ensure the value is a string to avoid PHP strpos() errors
+					return [
+						f.value.field,
+						f.value.operator,
+						// Convert all values to strings to avoid PHP type errors
+						String(f.value.value)
+					];
+				});
 
 				// Create the query parameters
 				const queryParams = {

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -78,7 +78,8 @@ const updateFilters = (onFilterUpdate, setFilters) => {
 			.map(f => {
 				// Ensure the filter has the expected structure
 				if (f.value && f.value.field && f.value.operator && f.value.value !== undefined) {
-					return [f.value.field, f.value.operator, f.value.value];
+					// Convert value to string to avoid PHP strpos() errors
+					return [f.value.field, f.value.operator, String(f.value.value)];
 				}
 				// Fallback for unexpected filter format
 				return null;

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -19,16 +19,20 @@ import FiltersForm from './filtersForm';
 
 const buildFilter = (filter, enabled = true) => {
 	const [ field, operator, value ] = Array.isArray(filter) ? filter : [filter.field, filter.operator, filter.value];
-	const hasMultipleWords = value.trim().includes(' ') || value.trim().includes(',');
-	const label = `${field} ${operator} ${value}`;
+	// Convert value to string before using trim() to avoid "value.trim is not a function" error
+	const valueStr = String(value);
+	const hasMultipleWords = valueStr.trim().includes(' ') || valueStr.trim().includes(',');
+	const label = `${field} ${operator} ${valueStr}`;
 
 	return {
 		enabled,
 		value: {
 			field,
 			operator,
+			// Store the original value to maintain type for API calls
 			value,
 		},
+		// Use the string version for display
 		compact: hasMultipleWords ? `${field} ${operator} ...` : label,
 		label,
 	}

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { FlexItem, Flex } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, trash } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import FiltersForm from './filtersForm';
+
+
+const buildFilter = (filter, enabled = true) => {
+	const [ field, operator, value ] = Array.isArray(filter) ? filter : [filter.field, filter.operator, filter.value];
+	const hasMultipleWords = value.trim().includes(' ') || value.trim().includes(',');
+	const label = `${field} ${operator} ${value}`;
+
+	return {
+		enabled,
+		value: {
+			field,
+			operator,
+			value,
+		},
+		compact: hasMultipleWords ? `${field} ${operator} ...` : label,
+		label,
+	}
+}
+
+const updateFilters = (onFilterUpdate, setFilters) => {
+	return (filters => {
+		setFilters(filters);
+		const filterList = filters
+			.filter(f => f.enabled)
+			.map(f => [f.value.field, f.value.operator, f.value.value]);
+		onFilterUpdate({ filters: filterList });
+	});
+}
+
+export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false }) => {
+	const [filters, setFilters] = useState([]);
+	const [isOpen, setIsOpen] = useState(false);
+
+	useEffect(() => {
+		if (propFilters.length > 0) {
+			const updatedFilters = propFilters.map(filter => buildFilter(filter));
+			setFilters(updatedFilters);
+		}
+	}, [propFilters]);
+
+
+	const handleFilterUpdate =  updateFilters(onFiltersUpdate, setFilters);
+
+	const handleFilterAdd = (filter) => {
+		const updatedFilters = [...filters, buildFilter(filter)];
+		handleFilterUpdate(updatedFilters);
+	};
+
+	const handleFilterRemove = (indexToRemove) => {
+		const updatedFilters = filters.filter((_, index) => index !== indexToRemove);
+		handleFilterUpdate(updatedFilters);
+	};
+
+	const handleToggleFilter = (indexToDisable) => {
+		const updatedFilters = filters.map((filter, index) => {
+			if (index === indexToDisable) {
+				return { ...filter, enabled: !filter.enabled };
+			}
+			return filter;
+		});
+		handleFilterUpdate(updatedFilters);
+	}
+	const toggleOpen = () => {
+		if (!loading) {
+			setIsOpen(!isOpen);
+		}
+	};
+
+	return (
+		<div className="wpcloud-metrics-filters__container" style={{ position: 'relative' }}>
+			<summary
+				onClick={toggleOpen}
+				style={{
+					cursor: loading ? 'not-allowed' : 'pointer',
+					opacity: loading ? 0.6 : 1
+				}}
+			>
+				{filters.length > 0 ? __(`Filters (${filters.filter(f => f.enabled).length})`) : __('Filters')}
+			</summary>
+			<div
+				className="wpcloud-metrics-filters"
+				style={{
+					display: isOpen ? 'block' : 'none',
+					position: 'absolute',
+					zIndex: 1000,
+					background: 'white',
+					boxShadow: '0 2px 5px rgba(0,0,0,0.2)',
+					padding: '10px',
+					borderRadius: '4px',
+					width: '100%'
+				}}
+			>
+				<Flex className="wpcloud-metrics-filters__applied" justify="start" wrap="wrap" style={{ gap: '8px' }}>
+					{filters.map((filter, index) => (
+						<button
+							key={index}
+							className={
+								classnames(
+									"wpcloud-metrics-filters__filter secondary",
+									{ "disabled": !filter.enabled }
+								)}
+							{ ...( filter.compact != filter.detailed && { 'data-tooltip': filter.label } ) }
+							onClick={() => handleToggleFilter(index)}
+						>
+							<span className="wpcloud-metrics-filters__filter-text">
+								{filter.compact}
+							</span>
+							<Icon
+								onClick={(e) => {
+									e.stopPropagation(); // Stop event from bubbling up to parent button
+									handleFilterRemove(index);
+								}}
+								icon={trash} size={20} />
+						</button>
+					))}
+					<FiltersForm onFilterAdd={handleFilterAdd} />
+				</Flex>
+			</div>
+		</div>
+	)
+};

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { FlexItem, Flex } from '@wordpress/components';
+import { Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, trash } from '@wordpress/icons';
 

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -18,8 +18,38 @@ import FiltersForm from './filtersForm';
 
 
 const buildFilter = (filter, enabled = true) => {
-	const [ field, operator, value ] = Array.isArray(filter) ? filter : [filter.field, filter.operator, filter.value];
-	// Convert value to string before using trim() to avoid "value.trim is not a function" error
+	// Handle different filter formats
+	let field, operator, value;
+
+	if (Array.isArray(filter)) {
+		// Array format: [field, operator, value]
+		[field, operator, value] = filter;
+	} else if (filter && typeof filter === 'object') {
+		// Object format: {field, operator, value} or {value: {field, operator, value}}
+		if (filter.value && filter.value.field) {
+			// Format: {value: {field, operator, value}}
+			field = filter.value.field;
+			operator = filter.value.operator;
+			value = filter.value.value;
+		} else {
+			// Format: {field, operator, value}
+			field = filter.field;
+			operator = filter.operator;
+			value = filter.value;
+		}
+	} else {
+		// Invalid format, provide defaults
+		field = '';
+		operator = '=';
+		value = '';
+	}
+
+	// Ensure all values are defined
+	field = field || '';
+	operator = operator || '=';
+	value = value !== undefined ? value : '';
+
+	// Convert value to string for display
 	const valueStr = String(value);
 	const hasMultipleWords = valueStr.trim().includes(' ') || valueStr.trim().includes(',');
 	const label = `${field} ${operator} ${valueStr}`;
@@ -41,9 +71,20 @@ const buildFilter = (filter, enabled = true) => {
 const updateFilters = (onFilterUpdate, setFilters) => {
 	return (filters => {
 		setFilters(filters);
+		// Extract the field, operator, and value from each filter and create an array format
+		// that the API expects: [field, operator, value]
 		const filterList = filters
 			.filter(f => f.enabled)
-			.map(f => [f.value.field, f.value.operator, f.value.value]);
+			.map(f => {
+				// Ensure the filter has the expected structure
+				if (f.value && f.value.field && f.value.operator && f.value.value !== undefined) {
+					return [f.value.field, f.value.operator, f.value.value];
+				}
+				// Fallback for unexpected filter format
+				return null;
+			})
+			.filter(f => f !== null); // Remove any null entries
+
 		onFilterUpdate({ filters: filterList });
 	});
 }

--- a/plugin/blocks/src/components/graph/components/lib/filtersForm.js
+++ b/plugin/blocks/src/components/graph/components/lib/filtersForm.js
@@ -69,7 +69,16 @@ export default ({ onFilterAdd = () => {} }) => {
 
 		const handleAddFilter = () => {
 				if (field && operator && value) {
-						onFilterAdd({ field, operator, value });
+						// Convert value to number if it's numeric and using a numeric comparison operator
+						let processedValue = value;
+						if (['>','>=','<','<='].includes(operator) && !isNaN(Number(value))) {
+								processedValue = Number(value);
+						} else if (field === 'http_status' && !isNaN(Number(value))) {
+								// HTTP status codes should be numbers
+								processedValue = Number(value);
+						}
+
+						onFilterAdd({ field, operator, value: processedValue });
 						resetForm();
 						setIsOpen(false); // Close the dropdown after adding a filter
 				}

--- a/plugin/blocks/src/components/graph/components/lib/filtersForm.js
+++ b/plugin/blocks/src/components/graph/components/lib/filtersForm.js
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { FlexItem } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+// Field options (dimensions)
+const fieldOptions = {
+		'http_verb': __('HTTP Verb'),
+		'http_status': __('HTTP Status')
+};
+
+// Operator options
+const operatorOptions = {
+		'=': __('is'),
+		'!=': __('is not'),
+		'IN': __('is one of'),
+		'NOT IN': __('is not one of'),
+		'>': __('greater than'),
+		'>=': __('greater than or equal to'),
+		'<': __('less than'),
+		'<=': __('less than or equal to'),
+};
+
+// Validator function to check if the field allows the operator
+const isOperatorValidForField = (field, operator) => {
+		// For now, always return true
+		// This can be expanded later to validate specific operators for different fields
+		return true;
+};
+
+// Check if operator accepts multiple values
+const operatorAcceptsMultipleValues = (operator) => {
+		return operator === 'IN' || operator === 'NOT IN';
+};
+
+export default ({ onFilterAdd = () => {} }) => {
+		const [field, setField] = useState('');
+		const [operator, setOperator] = useState('');
+		const [value, setValue] = useState('');
+		const [isOpen, setIsOpen] = useState(false);
+
+		const handleFieldChange = (event) => {
+				setField(event.target.value);
+		};
+
+		const handleOperatorChange = (event) => {
+				setOperator(event.target.value);
+		};
+
+		const handleValueChange = (event) => {
+				setValue(event.target.value);
+		};
+
+		const resetForm = () => {
+				setField('');
+				setOperator('');
+				setValue('');
+		};
+
+		const handleAddFilter = () => {
+				if (field && operator && value) {
+						onFilterAdd({ field, operator, value });
+						resetForm();
+						setIsOpen(false); // Close the dropdown after adding a filter
+				}
+		};
+
+		const handleKeyDown = (event) => {
+				if (event.key === 'Enter' && field && operator && value) {
+						event.preventDefault();
+						handleAddFilter();
+				}
+		};
+
+		return (
+			<details
+					className="wpcloud-metrics-filters-picker no-border dropdown"
+					open={isOpen}
+					onToggle={(e) => setIsOpen(e.target.open)}
+					style={{ position: 'relative' }}
+			>
+					<summary style={{width: 'fit-content', marginLeft: '6px'}}>{__('+ Add Filter')}</summary>
+					<ul className="wpcloud-metrics-filters-picker__options" style={{ position: 'absolute', zIndex: 1000, background: 'white', boxShadow: '0 2px 5px rgba(0,0,0,0.2)', width: '400px', maxWidth: '100vw' }}>
+							<li>
+									<div className="wpcloud-metrics-filters-picker__controls">
+											<div className="wpcloud-metrics-filters-picker__inputs">
+													<div className="wpcloud-metrics-filters-picker__field">
+															<label htmlFor="filter-field" className="screen-reader-text">{__('Field')}</label>
+															<select
+																	id="filter-field"
+																	value={field}
+																	onChange={handleFieldChange}
+																	aria-label={__('Field')}
+															>
+																	<option value="">{__('Field')}</option>
+																	{Object.entries(fieldOptions).map(([value, label]) => (
+																			<option key={value} value={value}>{label}</option>
+																	))}
+															</select>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__operator">
+															<label htmlFor="filter-operator" className="screen-reader-text">{__('Operator')}</label>
+															<select
+																	id="filter-operator"
+																	value={operator}
+																	onChange={handleOperatorChange}
+																	disabled={!field}
+																	aria-label={__('Operator')}
+															>
+																	<option value="">{__('Operator')}</option>
+																	{Object.entries(operatorOptions).map(([value, label]) => (
+																			<option
+																					key={value}
+																					value={value}
+																					disabled={field && !isOperatorValidForField(field, value)}
+																			>
+																					{label}
+																			</option>
+																	))}
+															</select>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__value">
+															<label htmlFor="filter-value" className="screen-reader-text">{__('Value')}</label>
+															<input
+																	type="text"
+																	id="filter-value"
+																	value={value}
+																	onChange={handleValueChange}
+																	onKeyDown={handleKeyDown}
+																	disabled={!field || !operator}
+																	placeholder={operatorAcceptsMultipleValues(operator) ? __('Value one, Value two, ...') : __('Value')}
+																	aria-label={__('Value')}
+															/>
+													</div>
+													<div className="wpcloud-metrics-filters-picker__apply">
+															<button
+																	onClick={handleAddFilter}
+																	disabled={!field || !operator || !value}
+															>
+																	{__('Apply')}
+															</button>
+													</div>
+											</div>
+									</div>
+							</li>
+					</ul>
+			</details>
+		);
+};

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -3,7 +3,8 @@ import { stackedOptions, defaultOptions, barOptions, lineOptions, areaOptions } 
 
 // Remove this amount from the container height to fit the graph legend.
 const fitGraphHeight = 75;
-const fitGraphWidth = 20;
+// Reduced the width adjustment to ensure graphs aren't too skinny
+const fitGraphWidth = 10;
 
 export default (options) => {
 	const {
@@ -17,29 +18,38 @@ export default (options) => {
 		orientation,
 	} = options;
 
-	const [width, setWidth] = useState(808);
-	const [height, setHeight] = useState(404);
+	// Set more appropriate initial values for flex containers
+	const [width, setWidth] = useState(containerRef?.current?.offsetWidth || 808);
+	const [height, setHeight] = useState(containerRef?.current?.offsetHeight || 404);
 
 	useEffect(() => {
 		const updateSize = () => {
 			if ( containerRef.current ) {
-				setWidth( containerRef.current.offsetWidth - fitGraphWidth );
-				setHeight( containerRef.current.offsetHeight - fitGraphHeight );
+				const newWidth = containerRef.current.offsetWidth - fitGraphWidth;
+				const newHeight = containerRef.current.offsetHeight - fitGraphHeight;
+
+				// Only update if the size has actually changed
+				if (newWidth !== width || newHeight !== height) {
+					setWidth(newWidth);
+					setHeight(newHeight);
+				}
 			}
 		};
 
 		updateSize(); // Initial update
 
-		const resizeObserver = new ResizeObserver( () => {
+		const resizeObserver = new ResizeObserver(() => {
 			if (containerRef.current) {
 				updateSize();
 			}
 		});
+
 		if (containerRef.current) {
-			resizeObserver.observe( containerRef.current );
+			resizeObserver.observe(containerRef.current);
 		}
+
 		return () => resizeObserver.disconnect();
-	}, [ containerRef ]);
+	}, [containerRef, width, height]);
 
 	let graphOptions = {
 		title,

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -26,7 +26,7 @@ import './editor.scss';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth  } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -75,6 +75,11 @@ export default function Edit( { attributes, setAttributes } ) {
 					label={ __( 'Show Legend' ) }
 					checked={ showLegend }
 					onChange={ update('showLegend') }
+				/>
+				<ToggleControl
+					label={ __( 'Show Filters' ) }
+					checked={ showFilters }
+					onChange={ update('showFilters') }
 				/>
 			</PanelBody>
 			<PanelBody title={__('Graph Data')}>

--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$summarize = $params['summarize'] ?? false;
 
 				$options = array(
-					'max_bucket_size'      => $params['top_x'] ?? 20, // Metrics API has top_x as max_bucket_size.
+					'top_x'      => $params['top_x'] ?? 20,
 					'resolution' => $params['resolution'] ?? 10,
 				);
 
@@ -176,7 +176,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 					if ( json_last_error() !== JSON_ERROR_NONE ) {
 						return new WP_REST_Response( esc_html__( 'Invalid filters', 'wpcloud' ), 400 );
 					}
-					$options['filters'] = $filters;
+					$options['filters'] = $this->convert_filters_format( $filters );
 				}
 
 				$site_id = $params['site_id'] ?? null;
@@ -289,6 +289,42 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				return new WP_Error( 'rest_invalid_param', wp_sprintf( esc_html__( 'Invalid %s time', 'wpcloud' ), $position ), array( 'status' => 400 ) );
 			}
 			return $ts;
+		}
+
+		/**
+		 * Convert filters from array format to object format.
+		 *
+		 * @param array $filters The filters in array format.
+		 * @return array The filters in object format.
+		 */
+		public function convert_filters_format( array $filters ): array {
+			$converted_filters = array();
+
+			foreach ( $filters as $filter ) {
+				if ( ! is_array( $filter ) || count( $filter ) < 3 ) {
+					// Skip invalid filters.
+					wpcloud_l( 'Invalid filter format', $filter );
+					continue;
+				}
+				$value = $filter[2];
+
+				$filter_object = array(
+					'column'   => $filter[0],
+					'operator' => $filter[1],
+					'value'    => $value,
+				);
+
+				// Check if the value contains commas, indicating multiple values.
+				if ( strpos( $value, ',' ) !== false ) {
+					// Split the value by commas and trim whitespace.
+					$values                 = array_map( 'trim', explode( ',', $value ) );
+					$filter_object['value'] = $values;
+				}
+
+				$converted_filters[] = $filter_object;
+			}
+
+			return $converted_filters;
 		}
 
 		/**

--- a/plugin/tests/js/components/graph/graph.test.js
+++ b/plugin/tests/js/components/graph/graph.test.js
@@ -11,6 +11,19 @@ import Graph from '../../../../blocks/src/components/graph/components/graph';
 import stationApi from '@wpcloud/utils/api';
 import { ApiContext } from '@wpcloud/metrics/components/apiContext';
 
+// Mock the WordPress components
+jest.mock('@wordpress/components', () => ({
+    Flex: ({ children }) => <div className="mock-flex">{children}</div>,
+    FlexItem: ({ children }) => <div className="mock-flex-item">{children}</div>,
+    Spinner: () => <div className="mock-spinner">Loading...</div>,
+}));
+
+// Mock the WordPress icons
+jest.mock('@wordpress/icons', () => ({
+    Icon: ({ icon }) => <span className="mock-icon">{icon}</span>,
+    trash: 'trash-icon',
+}));
+
 // Mock the stationApi.get method
 jest.mock('@wpcloud/utils/api', () => ({
     get: jest.fn(),


### PR DESCRIPTION
This adds a UI to add graph filters to a graph on the frontend. It also adds a block option to disable the filters UI

Adding a filter will also add a URL param so that reloading or sharing the URL will apply the same filters to the same graph.

### Screens

![Screen Recording 2025-04-24 at 12 18 19 AM](https://github.com/user-attachments/assets/333aafb1-c2ad-4038-b28f-8ee89a81efb5)

### Next
- Styling: I was mostly focused on overall layout and behavior. The filters still need some styling clean up
- Available Dimenions: For now the dimensions are hard coded. The available dimensions should be dynamically generate per the graph metric, either from the fronten or added as data attributes when saving the block
- Query param: the query param filter is ugly. That should be encoded to make it friendlier to share.