### PR TITLE
Metrics: add predefined filters to the graphs in the editor

### DIFF
--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -99,6 +99,11 @@
 		"predefinedFilters" : {
 			"type" : "array",
 			"default" : []
+		},
+		"allowFrontendFilters" : {
+			"type" : "boolean",
+			"default" : true,
+			"description": "Controls whether users can add, remove, or modify filters on the frontend"
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/block.json
+++ b/plugin/blocks/src/components/graph/block.json
@@ -95,6 +95,10 @@
 		"showFilters" : {
 			"type" : "boolean",
 			"default" : true
+		},
+		"predefinedFilters" : {
+			"type" : "array",
+			"default" : []
 		}
 	}
 }

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -124,7 +124,10 @@ export default function Graph( props ) {
 		showFilters = true,
 
 		// Predefined filters from block attributes
-		predefinedFilters = []
+		predefinedFilters = [],
+
+		// Allow frontend filter building
+		allowFrontendFilters = true
 
 	} = props;
 
@@ -337,6 +340,7 @@ export default function Graph( props ) {
 						filters={filters}
 						onFiltersUpdate={handleFiltersUpdate}
 						loading={loading}
+						allowFrontendFilters={allowFrontendFilters}
 					/>
 				</div>
 			)}

--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -121,7 +121,10 @@ export default function Graph( props ) {
 		id = `graph-${metric}-${dimension}`,
 
 		// Show filters toggle
-		showFilters = true
+		showFilters = true,
+
+		// Predefined filters from block attributes
+		predefinedFilters = []
 
 	} = props;
 
@@ -153,8 +156,43 @@ export default function Graph( props ) {
 	// Initialize filters from URL parameters if available
 	const [ filters, setFilters ] = useState([]);
 
-	// Load filters from URL on mount
+	// Convert predefined filters to filter objects
+	const convertPredefinedFilters = (filters) => {
+		if (!filters || !Array.isArray(filters) || filters.length === 0) {
+			return [];
+		}
+
+		return filters.map(filter => {
+			// Handle array format [field, operator, value]
+			if (Array.isArray(filter)) {
+				const [field, operator, value] = filter;
+				return {
+					enabled: true,
+					value: {
+						field,
+						operator,
+						value
+					},
+					compact: `${field} ${operator} ${value}`,
+					label: `${field} ${operator} ${value}`
+				};
+			}
+			return null;
+		}).filter(f => f !== null);
+	};
+
+	// Load filters from predefined filters or URL on mount
 	useEffect(() => {
+		// First check if we have predefined filters from block attributes
+		if (predefinedFilters && Array.isArray(predefinedFilters) && predefinedFilters.length > 0) {
+			const blockFilters = convertPredefinedFilters(predefinedFilters);
+			if (blockFilters.length > 0) {
+				setFilters(blockFilters);
+				return; // Use predefined filters, don't check URL
+			}
+		}
+
+		// If no predefined filters, try to get from URL
 		if (typeof window !== 'undefined') {
 			try {
 				const urlFilters = getFiltersFromUrl(graphId);
@@ -165,7 +203,7 @@ export default function Graph( props ) {
 				console.error('Error initializing filters:', error);
 			}
 		}
-	}, [graphId]);
+	}, [graphId, predefinedFilters]);
 
 	const containerRef = useRef(null);
 	// Ensure the container takes full width of parent and has appropriate minimum dimensions

--- a/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
+++ b/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
@@ -1,0 +1,232 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+    Button,
+    Flex,
+    FlexItem,
+    Panel,
+    PanelBody,
+    PanelRow,
+    SelectControl,
+    TextControl,
+    Icon
+} from '@wordpress/components';
+import { trash } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+
+// Field options (dimensions) - same as in filtersForm.js
+const fieldOptions = {
+    'http_verb': __('HTTP Verb'),
+    'http_status': __('HTTP Status')
+};
+
+// Operator options - same as in filtersForm.js
+const operatorOptions = {
+    '=': __('is'),
+    '!=': __('is not'),
+    'IN': __('is one of'),
+    'NOT IN': __('is not one of'),
+    '>': __('greater than'),
+    '>=': __('greater than or equal to'),
+    '<': __('less than'),
+    '<=': __('less than or equal to'),
+};
+
+// Validator function to check if the field allows the operator
+const isOperatorValidForField = (field, operator) => {
+    // For now, always return true
+    // This can be expanded later to validate specific operators for different fields
+    return true;
+};
+
+// Check if operator accepts multiple values
+const operatorAcceptsMultipleValues = (operator) => {
+    return operator === 'IN' || operator === 'NOT IN';
+};
+
+/**
+ * Convert a filter from the array format [field, operator, value] to an object format
+ *
+ * @param {Array} filter - Filter in array format [field, operator, value]
+ * @returns {Object} - Filter in object format {field, operator, value}
+ */
+const arrayToObjectFilter = (filter) => {
+    if (Array.isArray(filter)) {
+        return {
+            field: filter[0],
+            operator: filter[1],
+            value: filter[2]
+        };
+    }
+    return filter;
+};
+
+/**
+ * Convert a filter from the object format {field, operator, value} to an array format
+ *
+ * @param {Object} filter - Filter in object format {field, operator, value}
+ * @returns {Array} - Filter in array format [field, operator, value]
+ */
+const objectToArrayFilter = (filter) => {
+    if (filter && typeof filter === 'object' && !Array.isArray(filter)) {
+        return [filter.field, filter.operator, filter.value];
+    }
+    return filter;
+};
+
+/**
+ * Component for building and managing predefined filters in the block editor
+ */
+export default function FilterBuilder({ filters = [], onChange }) {
+    const [field, setField] = useState('');
+    const [operator, setOperator] = useState('');
+    const [value, setValue] = useState('');
+
+    const handleFieldChange = (newField) => {
+        setField(newField);
+    };
+
+    const handleOperatorChange = (newOperator) => {
+        setOperator(newOperator);
+    };
+
+    const handleValueChange = (newValue) => {
+        setValue(newValue);
+    };
+
+    const resetForm = () => {
+        setField('');
+        setOperator('');
+        setValue('');
+    };
+
+    const handleAddFilter = () => {
+        if (field && operator && value) {
+            // Convert value to number if it's numeric and using a numeric comparison operator
+            let processedValue = value;
+            if (['>','>=','<','<='].includes(operator) && !isNaN(Number(value))) {
+                processedValue = Number(value);
+            } else if (field === 'http_status' && !isNaN(Number(value))) {
+                // HTTP status codes should be numbers
+                processedValue = Number(value);
+            }
+
+            // Create the new filter in array format [field, operator, value]
+            const newFilter = [field, operator, processedValue];
+
+            // Add the new filter to the existing filters
+            const updatedFilters = [...filters, newFilter];
+
+            // Call the onChange callback with the updated filters
+            onChange(updatedFilters);
+
+            // Reset the form
+            resetForm();
+        }
+    };
+
+    const handleRemoveFilter = (indexToRemove) => {
+        const updatedFilters = filters.filter((_, index) => index !== indexToRemove);
+        onChange(updatedFilters);
+    };
+
+    return (
+        <div className="wpcloud-filter-builder">
+            <PanelBody title={__('Predefined Filters')} initialOpen={false}>
+                <PanelRow>
+                    <div style={{ width: '100%' }}>
+                        <Flex direction="column" gap={4}>
+                            {/* Filter input form */}
+                            <Flex direction="column" gap={2}>
+                                <SelectControl
+                                    label={__('Field')}
+                                    value={field}
+                                    options={[
+                                        { label: __('Select a field'), value: '' },
+                                        ...Object.entries(fieldOptions).map(([value, label]) => ({
+                                            label,
+                                            value
+                                        }))
+                                    ]}
+                                    onChange={handleFieldChange}
+                                />
+
+                                <SelectControl
+                                    label={__('Operator')}
+                                    value={operator}
+                                    options={[
+                                        { label: __('Select an operator'), value: '' },
+                                        ...Object.entries(operatorOptions).map(([value, label]) => ({
+                                            label,
+                                            value,
+                                            disabled: field && !isOperatorValidForField(field, value)
+                                        }))
+                                    ]}
+                                    onChange={handleOperatorChange}
+                                    disabled={!field}
+                                />
+
+                                <TextControl
+                                    label={__('Value')}
+                                    value={value}
+                                    onChange={handleValueChange}
+                                    placeholder={
+                                        operatorAcceptsMultipleValues(operator)
+                                            ? __('Value one, Value two, ...')
+                                            : __('Value')
+                                    }
+                                    disabled={!field || !operator}
+                                />
+
+                                <Button
+                                    variant="primary"
+                                    onClick={handleAddFilter}
+                                    disabled={!field || !operator || !value}
+                                >
+                                    {__('Add Filter')}
+                                </Button>
+                            </Flex>
+
+                            {/* List of existing filters */}
+                            {filters.length > 0 && (
+                                <div className="wpcloud-filter-builder__filters">
+                                    <h3>{__('Current Filters')}</h3>
+                                    <Flex direction="column" gap={2}>
+                                        {filters.map((filter, index) => {
+                                            // Convert to object format for easier access
+                                            const f = arrayToObjectFilter(filter);
+                                            return (
+                                                <Flex key={index} align="center" justify="space-between">
+                                                    <span>
+                                                        {`${f.field} ${f.operator} ${f.value}`}
+                                                    </span>
+                                                    <Button
+                                                        isDestructive
+                                                        icon={trash}
+                                                        onClick={() => handleRemoveFilter(index)}
+                                                        label={__('Remove filter')}
+                                                        showTooltip
+                                                    />
+                                                </Flex>
+                                            );
+                                        })}
+                                    </Flex>
+                                </div>
+                            )}
+                        </Flex>
+                    </div>
+                </PanelRow>
+            </PanelBody>
+        </div>
+    );
+}

--- a/plugin/blocks/src/components/graph/components/lib/filters.js
+++ b/plugin/blocks/src/components/graph/components/lib/filters.js
@@ -90,7 +90,7 @@ const updateFilters = (onFilterUpdate, setFilters) => {
 	});
 }
 
-export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false }) => {
+export default ({ onFiltersUpdate = console.log, filters: propFilters = [], loading = false, allowFrontendFilters = true }) => {
 	const [filters, setFilters] = useState([]);
 	const [isOpen, setIsOpen] = useState(false);
 
@@ -168,15 +168,17 @@ export default ({ onFiltersUpdate = console.log, filters: propFilters = [], load
 							<span className="wpcloud-metrics-filters__filter-text">
 								{filter.compact}
 							</span>
-							<Icon
-								onClick={(e) => {
-									e.stopPropagation(); // Stop event from bubbling up to parent button
-									handleFilterRemove(index);
-								}}
-								icon={trash} size={20} />
+							{allowFrontendFilters && (
+								<Icon
+									onClick={(e) => {
+										e.stopPropagation(); // Stop event from bubbling up to parent button
+										handleFilterRemove(index);
+									}}
+									icon={trash} size={20} />
+							)}
 						</button>
 					))}
-					<FiltersForm onFilterAdd={handleFilterAdd} />
+					{allowFrontendFilters && <FiltersForm onFilterAdd={handleFilterAdd} />}
 				</Flex>
 			</div>
 		</div>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -31,7 +31,7 @@ import FilterBuilder from './components/lib/filterBuilder';
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters, predefinedFilters } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters, predefinedFilters, allowFrontendFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -82,7 +82,8 @@ export default function Edit( { attributes, setAttributes } ) {
 					onChange={ update('showLegend') }
 				/>
 				<ToggleControl
-					label={ __( 'Show Filters' ) }
+					label={ __( 'Enable Filter Controls' ) }
+					help={ __( 'Allow users to view and interact with filters on the frontend. See the `Predefined Filters` section below to add default filters' ) }
 					checked={ showFilters }
 					onChange={ update('showFilters') }
 				/>
@@ -161,10 +162,21 @@ export default function Edit( { attributes, setAttributes } ) {
 			</PanelBody>
 
 			{showFilters && (
-				<FilterBuilder
-					filters={predefinedFilters}
-					onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
-				/>
+				<>
+					<PanelBody title={__('Filter Settings')}>
+						<ToggleControl
+							label={ __( 'Allow Frontend Filter Building' ) }
+							help={ __( 'Enable users to add and remove filters on the frontend' ) }
+							checked={ allowFrontendFilters }
+							onChange={ update('allowFrontendFilters') }
+						/>
+					</PanelBody>
+
+					<FilterBuilder
+						filters={predefinedFilters}
+						onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+					/>
+				</>
 			)}
 		</InspectorControls>
 	)

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -23,10 +23,15 @@ import apiFetch from '@wordpress/api-fetch';
 import { updateAttribute } from '@wpcloud/controls';
 import './editor.scss';
 
+/**
+ * Internal dependencies
+ */
+import FilterBuilder from './components/lib/filterBuilder';
+
 
 export default function Edit( { attributes, setAttributes } ) {
 
-	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters } = attributes;
+	const { title, type, orientation, showLegend, metric, dimension, resolution, topX, summarize, minWidth, showFilters, predefinedFilters } = attributes;
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
@@ -153,7 +158,14 @@ export default function Edit( { attributes, setAttributes } ) {
 					value={ minWidth }
 					onChange={ update('minWidth') }
 				/>
-				</PanelBody>
+			</PanelBody>
+
+			{showFilters && (
+				<FilterBuilder
+					filters={predefinedFilters}
+					onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+				/>
+			)}
 		</InspectorControls>
 	)
 	return (


### PR DESCRIPTION
This adds the option to set predefined filters on the metrics blocks in the editor.
Turning off filter editing on the frontend does not remove the predefined filters. 

If editing filters is allowed, removing the predefined filter does not show up in the URL. Adding a new filter, which will result in a new URL param, will not override the predefined filters.
## Screens
<img width="290" alt="Screenshot 2025-04-24 at 12 57 21 AM" src="https://github.com/user-attachments/assets/9c990f2c-9b5b-48d3-a798-c7911d505a1e" />
<img width="373" alt="Screenshot 2025-04-24 at 12 57 43 AM" src="https://github.com/user-attachments/assets/ef6b0784-efe8-4103-8245-814e587558da" />


Note: as with #335 the dimensions that can be filtered are hard coded for now. 