### PR TITLE
Graph Block - Always render filter controls to editrs

### DIFF
--- a/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
+++ b/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
@@ -142,7 +142,7 @@ export default function FilterBuilder({ filters = [], onChange }) {
 
     return (
         <div className="wpcloud-filter-builder">
-            <PanelBody title={__('Predefined Filters')} initialOpen={false}>
+            <PanelBody title={__('Graph Filters')} initialOpen={false}>
                 <PanelRow>
                     <div style={{ width: '100%' }}>
                         <Flex direction="column" gap={4}>

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -153,6 +153,11 @@ export default function Edit( { attributes, setAttributes } ) {
 
 			</PanelBody>
 
+			<FilterBuilder
+				filters={predefinedFilters}
+				onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
+			/>
+
 			<PanelBody title={__('Graph Size')}>
 				<TextControl
 					label={ __( 'Minimum Width' ) }
@@ -161,12 +166,6 @@ export default function Edit( { attributes, setAttributes } ) {
 				/>
 			</PanelBody>
 
-			{allowFrontendFilters && (
-				<FilterBuilder
-					filters={predefinedFilters}
-					onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
-				/>
-			)}
 		</InspectorControls>
 	)
 	return (


### PR DESCRIPTION
Filter controls should always be available to editors. Remove logic that was hiding filters when Allow Filters toggle was disabled.

rename to Graph Filters and move before sizing settings as it goes hand in hand with Data section.