### PR TITLE
Update/metric dependency

### DIFF
--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -175,7 +175,8 @@ export default function Edit( { attributes, setAttributes } ) {
 						/>
 						<SelectControl
 							label={__('Dimension')}
-							value={dimension}options={[ ...dimensionOptions, ]}
+							value={dimension}
+							options={[ ...dimensionOptions, ]}
 							onChange={update('dimension')}
 						/>
 						<NumberControl

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -35,18 +35,93 @@ export default function Edit( { attributes, setAttributes } ) {
 	const update = updateAttribute(setAttributes);
 
 	const [metrics, setMetrics] = useState({});
-	const [dimensions, setDimensions] = useState({});
+	const [dimensionOptions, setDimensionOptions] = useState({});
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
 		async function fetchAvailable() {
 			const available = await apiFetch({ path: 'wpcloud-station/v1/metrics/available' });
 			setMetrics(available.metrics);
-			setDimensions(available.dimensions);
 			setLoading(false);
 		}
 		fetchAvailable();
 	}, []);
+
+	// Define all possible options for Dimensions based on Metrics
+	// @TODo - Move this to use the php function so single mapping?
+	//  Or alternatively update the json response to contain the mapping groups so not making multiple calls.
+	const getDimensionsMap = function( metric ) {
+		if( metric.startsWith( 'php_') && metric !== 'php_response_time_sum' ) {
+			return [
+				{ label: 'HTTP Verb', value: 'http_verb' },
+				{ label: 'HTTP Host', value: 'http_host' },
+				{ label: 'DataCenter', value: 'datacenter' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+				{ label: 'Burst Status', value: 'burst_status' },
+			];
+		} else if ( metric.startsWith( 'mysql_pool_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+			];
+		} else if ( metric.startsWith( 'mysql_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			];
+		}else if ( metric.startsWith( 'cgroup_' ) ) {
+			return [
+				{ label: 'Pool Server Number', value: 'pool' },
+				{ label: 'Pool Server Name', value: 'server' },
+				{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			];
+		} else if ( metric === 'uniques' || metric === 'views' ) {
+			return [
+				{ label: 'Host Name', value: 'hostname' },
+			];
+		}
+		return [
+			{ label: 'Server Protocol (HTTP Version)', value: 'server_protocol' },
+			{ label: 'Request Method (HTTP Verb)', value: 'request_method' },
+			{ label: 'Host Name', value: 'http_host' },
+			{ label: 'Response Code (HTTP Status)', value: 'http_status' },
+			{ label: 'User Agent', value: 'http_user_agent' },
+			{ label: 'Referer Domain', value: 'referer_domain' },
+			{ label: 'Request Renderer', value: 'request_renderer' },
+			{ label: 'Is Upstream Cached?', value: 'is_upstream_cached' },
+			{ label: 'WP Admin Ajax Action', value: 'admin_ajax_action' },
+			{ label: 'Visitor ASN', value: 'asn' },
+			{ label: 'Visitor Country Code', value: 'country_code' },
+			{ label: 'Visitor Is Crawler?', value: 'is_crawler' },
+			{ label: 'Visitor Device Type', value: 'device_type' },
+			{ label: 'Visitor Is Logged In?', value: 'visitor_is_logged_in' },
+			{ label: 'Visitor Operating System', value: 'visitor_os' },
+			{ label: 'Visitor Browser', value: 'visitor_browser' },
+			{ label: 'Edge Cache Status', value: 'edge_cache_status' },
+			{ label: 'Is Rate Limited?', value: 'is_rate_limited' },
+			{ label: 'Rate Limit Reason', value: 'rate_limit_reason' },
+			{ label: 'DataCenter', value: 'datacenter' },
+			{ label: 'Request URL (excluding Query String)', value: 'request_url_no_qs' },
+			{ label: 'Remote Address', value: 'remote_addr' },
+			{ label: 'Atomic Site ID', value: 'atomic_site_id' },
+			{ label: 'Proxy Type', value: 'proxy_type' },
+		]
+	};
+
+	// Update Dimension Options when Metric is selected.
+	useEffect( () => {
+		// Update Dimension options when metrics changes
+		if ( metrics ) {
+			// @ToDo - don't update if in same map.
+			const _dimensionOptions = getDimensionsMap(metric);
+			setDimensionOptions(_dimensionOptions);
+			// update dimension if map has changed.
+			if (! _dimensionOptions.some(dimObj => dimObj.value === dimension)) {
+				setAttributes({ 'dimension': _dimensionOptions[0].value });
+			}
+		}
+	}, [metric] );
 
 	const controls = (
 		<InspectorControls>
@@ -100,8 +175,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						/>
 						<SelectControl
 							label={__('Dimension')}
-							value={dimension}
-							options={Object.keys(dimensions).map((key) => ({ label: dimensions[key], value: key })) }
+							value={dimension}options={[ ...dimensionOptions, ]}
 							onChange={update('dimension')}
 						/>
 						<NumberControl

--- a/plugin/includes/class-wpcloud-metric-data-view.php
+++ b/plugin/includes/class-wpcloud-metric-data-view.php
@@ -53,7 +53,7 @@ class WPCLOUD_Metric_Data_View extends WPCLOUD_Metrics {
 			return new WP_Error( 'invalid_metric', 'Invalid metric', array( 'status' => 400 ) );
 		}
 
-		if ( ! array_key_exists( $this->dimension, $this->get_available_dimensions() ) ) {
+		if ( ! array_key_exists( $this->dimension, $this->get_available_dimensions( $this->metric ) ) ) {
 			return new WP_Error( 'invalid_dimension', 'Invalid dimension', array( 'status' => 400 ) );
 		}
 

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -163,20 +163,99 @@ class WPCloud_Metrics {
 	 */
 	public static function get_available_metrics(): array {
 		return array(
+			// Edge Request Logs
 			'requests'                   => __( 'Requests', 'wpcloud' ),
 			'requests_persec'            => __( 'Requests per second', 'wpcloud' ),
 			'response_bytes'             => __( 'Response bytes', 'wpcloud' ),
 			'response_bytes_persec'      => __( 'Response bytes per second', 'wpcloud' ),
 			'response_bytes_average'     => __( 'Response bytes average', 'wpcloud' ),
 			'response_time_average'      => __( 'Response time average', 'wpcloud' ),
-			'php_response_time_sum'      => __( 'PHP response time sum', 'wpcloud' ),
+			'php_response_time_sum'      => __( 'PHP response time (sum)', 'wpcloud' ),
+
+			/* Available but better as a dimension */
 			'edge_cache_hit_percentage'  => __( 'Edge cache hit percentage', 'wpcloud' ),
 			'edge_cache_miss_percentage' => __( 'Edge cache miss percentage', 'wpcloud' ),
+
+			// PHP-FPM Origin Logs
 			'php_cpu_time'               => __( 'PHP CPU time', 'wpcloud' ),
 			'php_cpu_time_persec'        => __( 'PHP CPU time per second', 'wpcloud' ),
 			'php_response_time'          => __( 'PHP response time', 'wpcloud' ),
 			'php_requests'               => __( 'PHP requests', 'wpcloud' ),
 			'php_requests_persec'        => __( 'PHP requests per second', 'wpcloud' ),
+			'php_workers_average'        => __( 'PHP workers_average', 'wpcloud' ),
+			'php_workers_min'            => __( 'PHP workers min', 'wpcloud' ),
+			'php_workers_max'			 => __( 'PHP workers max', 'wpcloud' ),
+
+			/* Available but better as a dimension
+			'php_requests_burst_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			'php_requests_limited_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			'php_requests_normal_percentage' => __( 'PHP requests burst percentage', 'wpcloud' ),
+			*/
+
+			// Edge based Unique Views
+			'uniques'					=> __( 'Unique Visits', 'wpcloud' ),
+			'views'						=> __( 'Page Views', 'wpcloud' ),
+
+			// MySQL Pool Stats
+			/* Available but does it make sense to share pool info with clients?
+			'mysql_pool_replication_lag_average' => __( 'MySQL Replication Lag', 'wpcloud' ),
+			*/
+
+			// cgroup User Stats
+			'cgroup_cpu_usage' => __( 'CPU Usage', 'wpcloud' ),
+			'cgroup_cpu_usage_persec' => __( 'CPU Usage per second', 'wpcloud' ),
+
+			// MySQL / MariaDB User Stats
+			// @todo We might want to simplify the list to most used :)
+			'mysql_total_connections' => __( 'MYSQL total connections', 'wpcloud' ),
+			'mysql_total_connections_persec' => __( 'MYSQL total connections per second', 'wpcloud' ),
+			'mysql_concurrent_connections' => __( 'MYSQL concurrent connections', 'wpcloud' ),
+			'mysql_concurrent_connections_persec' => __( 'MYSQL concurrent connections per second', 'wpcloud' ),
+			'mysql_connected_time' => __( 'MYSQL connected time', 'wpcloud' ),
+			'mysql_connected_time_persec' => __( 'MYSQL connected time per second', 'wpcloud' ),
+			'mysql_busy_time' => __( 'MYSQL busy time', 'wpcloud' ),
+			'mysql_busy_time_persec' => __( 'MYSQL busy time per second', 'wpcloud' ),
+			'mysql_cpu_time' => __( 'MYSQL cpu time', 'wpcloud' ),
+			'mysql_cpu_time_persec' => __( 'MYSQL cpu time per second', 'wpcloud' ),
+			'mysql_bytes_received' => __( 'MYSQL bytes received', 'wpcloud' ),
+			'mysql_bytes_received_persec' => __( 'MYSQL bytes received per second', 'wpcloud' ),
+			'mysql_bytes_sent' => __( 'MYSQL bytes sent', 'wpcloud' ),
+			'mysql_bytes_sent_persec' => __( 'MYSQL bytes sent', 'wpcloud' ),
+			'mysql_binlog_bytes_written' => __( 'MYSQL binlog bytes written', 'wpcloud' ),
+			'mysql_binlog_bytes_written_persec' => __( 'MYSQL binlog bytes written per second', 'wpcloud' ),
+			'mysql_rows_read' => __( 'MYSQL rows read', 'wpcloud' ),
+			'mysql_rows_read_persec' => __( 'MYSQL rows read per second', 'wpcloud' ),
+			'mysql_rows_sent' => __( 'MYSQL rows sent', 'wpcloud' ),
+			'mysql_rows_sent_persec' => __( 'MYSQL rows sent per second', 'wpcloud' ),
+			'mysql_rows_deleted' => __( 'MYSQL rows deleted', 'wpcloud' ),
+			'mysql_rows_deleted_persec' => __( 'MYSQL rows deleted per second', 'wpcloud' ),
+			'mysql_rows_inserted' => __( 'MYSQL rows inserted', 'wpcloud' ),
+			'mysql_rows_inserted_persec' => __( 'MYSQL rows inserted per second', 'wpcloud' ),
+			'mysql_rows_updated' => __( 'MYSQL rows updated', 'wpcloud' ),
+			'mysql_rows_updated_persec' => __( 'MYSQL rows updated per second', 'wpcloud' ),
+			'mysql_select_commands' => __( 'MYSQL select commands', 'wpcloud' ),
+			'mysql_select_commands_persec' => __( 'MYSQL select commands per second', 'wpcloud' ),
+			'mysql_update_commands' => __( 'MYSQL update commands', 'wpcloud' ),
+			'mysql_update_commands_persec' => __( 'MYSQL update commands per second', 'wpcloud' ),
+			'mysql_other_commands' => __( 'MYSQL other commands', 'wpcloud' ),
+			'mysql_other_commands_persec' => __( 'MYSQL other commands per second', 'wpcloud' ),
+			'mysql_commit_transactions' => __( 'MYSQL commit transactions', 'wpcloud' ),
+			'mysql_commit_transactions_persec' => __( 'MYSQL commit transactions per second', 'wpcloud' ),
+			'mysql_rollback_transactions' => __( 'MYSQL rollback transactions', 'wpcloud' ),
+			'mysql_rollback_transactions_persec' => __( 'MYSQL rollback transactions per second', 'wpcloud' ),
+			'mysql_denied_connections' => __( 'MYSQL denied connections', 'wpcloud' ),
+			'mysql_denied_connections_persec' => __( 'MYSQL denied connections per second', 'wpcloud' ),
+			'mysql_lost_connections' => __( 'MYSQL lost connections', 'wpcloud' ),
+			'mysql_lost_connections_persec' => __( 'MYSQL lost connections per second', 'wpcloud' ),
+			'mysql_access_denied' => __( 'MYSQL access denied', 'wpcloud' ),
+			'mysql_access_denied_persec' => __( 'MYSQL access denied per second', 'wpcloud' ),
+			'mysql_empty_queries' => __( 'MYSQL empty queries', 'wpcloud' ),
+			'mysql_empty_queries_persec' => __( 'MYSQL empty queries per second', 'wpcloud' ),
+			'mysql_total_ssl_connections' => __( 'MYSQL total ssl connections', 'wpcloud' ),
+			'mysql_total_ssl_connections_persec' => __( 'MYSQL total ssl connections per second', 'wpcloud' ),
+			'mysql_max_statement_time_exceeded' => __( 'MYSQL max statement time exceeded', 'wpcloud' ),
+			'mysql_max_statement_time_exceeded_persec' => __( 'MYSQL max statement time exceeded per second', 'wpcloud' ),
+
 		);
 	}
 
@@ -185,39 +264,71 @@ class WPCloud_Metrics {
 	 *
 	 * @return array The dimensions.
 	 */
-	public static function get_available_dimensions(): array {
-		return array(
-			'http_version'         => __( 'HTTP version', 'wpcloud' ),
-			'server_protocol'      => __( 'Server protocol', 'wpcloud' ),
-			'http_verb'            => __( 'HTTP verb', 'wpcloud' ),
-			'request_method'       => __( 'Request method', 'wpcloud' ),
-			'http_host'            => __( 'HTTP host', 'wpcloud' ),
-			'http_status'          => __( 'HTTP status', 'wpcloud' ),
-			'page_renderer'        => __( 'Page renderer', 'wpcloud' ),
-			'request_renderer'     => __( 'Request renderer', 'wpcloud' ),
-			'page_is_cached'       => __( 'Page is cached', 'wpcloud' ),
-			'is_upstream_cached'   => __( 'Is upstream cached', 'wpcloud' ),
-			'wp_admin_ajax_action' => __( 'WP admin AJAX action', 'wpcloud' ),
-			'visitor_asn'          => __( 'Visitor ASN', 'wpcloud' ),
-			'asn'                  => __( 'ASN', 'wpcloud' ),
-			'visitor_country_code' => __( 'Visitor country code', 'wpcloud' ),
-			'country_code'         => __( 'Country code', 'wpcloud' ),
-			'visitor_is_crawler'   => __( 'Visitor is crawler', 'wpcloud' ),
-			'is_crawler'           => __( 'Is crawler', 'wpcloud' ),
-			'visitor_device_type'  => __( 'Visitor device type', 'wpcloud' ),
-			'edge_cache_status'    => __( 'Edge cache status', 'wpcloud' ),
-			'is_rate_limited'      => __( 'Is rate limited', 'wpcloud' ),
-			'rate_limit_reason'    => __( 'Rate limit reason', 'wpcloud' ),
-			'datacenter'           => __( 'Datacenter', 'wpcloud' ),
-			'path'                 => __( 'Path', 'wpcloud' ),
-			'atomic_site_id'       => __( 'Atomic site ID', 'wpcloud' ),
-			'proxy_type'           => __( 'Proxy type', 'wpcloud' ),
-			/**
-			 * Planned
-			 * 'remote_address'      => __( 'Remote address', 'wpcloud' ),
-			 * 'http_user_agent'     => __( 'HTTP user agent', 'wpcloud' ),
-			 * 'http_referer'        => __( 'HTTP referer', 'wpcloud' ),
-			*/
-		);
+	public static function get_available_dimensions( $metric = null ): array {
+		if( ! empty( $metric ) && str_starts_with( $metric, 'mysql_pool_' ) ) {
+			// MySQL Pool Stats Dimensions
+			return array(
+				'pool'	 => __( 'Pool Server ID', 'wpcloud' ),
+				'server' => __( 'Pool Server Name', 'wpcloud' ),
+			);
+		} else if( ! empty( $metric ) && str_starts_with( $metric, 'mysql_' ) ) {
+			// MySQL User Stats Dimensions
+			return array(
+				'pool'				=> __( 'Pool Server ID', 'wpcloud' ),
+				'server' 			=> __( 'Pool Server Name', 'wpcloud' ),
+				'atomic_site_id'	=> __( 'Atomic site ID', 'wpcloud' ),
+			);
+		} else if( ! empty( $metric ) && str_starts_with( $metric, 'cgroup_' ) ) {
+			// cgroup User Stats Dimensions
+			return array(
+				'pool'				=> __( 'Pool Server ID', 'wpcloud' ),
+				'server' 			=> __( 'Pool Server Name', 'wpcloud' ),
+				'atomic_site_id'	=> __( 'Atomic site ID', 'wpcloud' ),
+			);
+		} else if( in_array( $metric, Array( 'uniques', 'views' ), true ) ) {
+			// Uniques and Views Dimensions
+			return array(
+				'hostname' => __('hostname', 'wpcloud'),
+			);
+		} else if(
+			! empty( $metric )
+			&& str_starts_with( $metric, 'php_' )
+			&& ! in_array( $metric, Array( 'php_response_time_sum' ), true ) ) {
+			// PHP-FPM Origin Dimensions
+			return array(
+				'http_verb'				=> __( 'HTTP Verb', 'wpcloud' ),
+				'http_host' 			=> __( 'HTTP Host', 'wpcloud' ),
+				'datacenter'			=> __( 'Datacenter', 'wpcloud' ),
+				'atomic_site_id'		=> __( 'Site ID', 'wpcloud' ),
+				'burst_status'			=> __( 'Burst Status', 'wpcloud' ),
+			);
+		} else {
+			// Edge Dimensions // Use for Default
+			return array(
+				'server_protocol'      => __( 'Server protocol', 'wpcloud' ),
+				'request_method'       => __( 'Request method', 'wpcloud' ),
+				'http_host'            => __( 'HTTP host', 'wpcloud' ),
+				'http_status'          => __( 'HTTP status', 'wpcloud' ),
+				'http_user_agent'      => __( 'HTTP User Agent', 'wpcloud' ),
+				'http_referer'         => __( 'HTTP referer', 'wpcloud' ),
+				'request_renderer'     => __( 'Request renderer', 'wpcloud' ),
+				'is_upstream_cached'   => __( 'Is upstream cached', 'wpcloud' ),
+				'wp_admin_ajax_action' => __( 'WP Admin AJAX action', 'wpcloud' ),
+				'visitor_asn'          => __( 'Visitor ASN', 'wpcloud' ),
+				'visitor_country_code' => __( 'Visitor country code', 'wpcloud' ),
+				'visitor_is_crawler'   => __( 'Visitor is crawler', 'wpcloud' ),
+				'visitor_device_type'  => __( 'Visitor device type', 'wpcloud' ),
+				'visitor_is_logged_in' => __( 'Visitor is logged In', 'wpcloud' ),
+				'visitor_os'           => __( 'Visitor OS', 'wpcloud' ),
+				'visitor_browser'      => __( 'Visitor Browser', 'wpcloud' ),
+				'edge_cache_status'    => __( 'Edge cache status', 'wpcloud' ),
+				'is_rate_limited'      => __( 'Is rate limited', 'wpcloud' ),
+				'rate_limit_reason'    => __( 'Rate limit reason', 'wpcloud' ),
+				'datacenter'           => __( 'Datacenter', 'wpcloud' ),
+				'path'                 => __( 'Path', 'wpcloud' ),
+				'atomic_site_id'       => __( 'Atomic site ID', 'wpcloud' ),
+				'proxy_type'           => __( 'Proxy type', 'wpcloud' ),
+			);
+		}
 	}
 }


### PR DESCRIPTION
The available Metrics from WP Cloud come from multiple sources that allow slicing by different dimensions. It should not be on users to know the mappings.

This update includes 2 modificaitons as outlined in https://github.com/Automattic/wpcloud-station/issues/320

Updates the available metrics/dimensions to align with current options from the Atomic API

adds logic so that when editing a Graph the dimension options update to reflect available options for the selected metric. If the existing dimension value is not a valid option it resets to the first option in current set.

This is a new branch of https://github.com/Automattic/wpcloud-station/pull/331 as during rebasing it got out of whack :)
