### PR TITLE
Graph Filters :: Update Filter 'field' to align with dimensions of selected graph metric

### DIFF
--- a/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
+++ b/plugin/blocks/src/components/graph/components/lib/filterBuilder.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * WordPress dependencies
@@ -23,12 +23,6 @@ import { trash } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-
-// Field options (dimensions) - same as in filtersForm.js
-const fieldOptions = {
-    'http_verb': __('HTTP Verb'),
-    'http_status': __('HTTP Status')
-};
 
 // Operator options - same as in filtersForm.js
 const operatorOptions = {
@@ -87,7 +81,7 @@ const objectToArrayFilter = (filter) => {
 /**
  * Component for building and managing predefined filters in the block editor
  */
-export default function FilterBuilder({ filters = [], onChange }) {
+export default function FilterBuilder({ filters = [], dimensionOptions = [], onChange }) {
     const [field, setField] = useState('');
     const [operator, setOperator] = useState('');
     const [value, setValue] = useState('');
@@ -105,10 +99,25 @@ export default function FilterBuilder({ filters = [], onChange }) {
     };
 
     const resetForm = () => {
-        setField('');
+		setField( dimensionOptions[0].value ); // select first option
         setOperator('');
         setValue('');
     };
+
+	// Update Columns when dimensions change
+	useEffect( () => {
+		if ( field ) {
+			// update field and filters if dimension is no longer valid.
+			// @todo -> is there any overlap where we may keep some filters?
+			if ( ! dimensionOptions.some(dimObj => dimObj.value === field)) {
+				setField( dimensionOptions[0].value );
+				onChange( [] ); // remove filters
+			}
+		} else {
+			// select first item if none selected.
+			setField( dimensionOptions[0].value );
+		}
+	}, [dimensionOptions] );
 
     const handleAddFilter = () => {
         if (field && operator && value) {
@@ -151,13 +160,7 @@ export default function FilterBuilder({ filters = [], onChange }) {
                                 <SelectControl
                                     label={__('Field')}
                                     value={field}
-                                    options={[
-                                        { label: __('Select a field'), value: '' },
-                                        ...Object.entries(fieldOptions).map(([value, label]) => ({
-                                            label,
-                                            value
-                                        }))
-                                    ]}
+									options={[ ...dimensionOptions, ]}
                                     onChange={handleFieldChange}
                                 />
 

--- a/plugin/blocks/src/components/graph/edit.js
+++ b/plugin/blocks/src/components/graph/edit.js
@@ -230,6 +230,7 @@ export default function Edit( { attributes, setAttributes } ) {
 
 			<FilterBuilder
 				filters={predefinedFilters}
+				dimensionOptions={dimensionOptions}
 				onChange={(newFilters) => setAttributes({ predefinedFilters: newFilters })}
 			/>
 


### PR DESCRIPTION
Handle the editor controls for syncing filters field options based on the selected metric. Does not update the front end filter at this time.

- When dimension field changes -> update field options && remove filters if don't apply.

https://github.com/Automattic/wpcloud-station/issues/340

<img width="274" alt="Screenshot 2025-04-24 at 12 01 20 PM" src="https://github.com/user-attachments/assets/cf4ccc08-ac4d-4567-97ac-7f59632a3ecc" />
