### PR TITLE
Metrics Block :: Align with no type attribute

### DIFF
--- a/plugin/blocks/src/metrics/view.js
+++ b/plugin/blocks/src/metrics/view.js
@@ -17,16 +17,13 @@ document.addEventListener('DOMContentLoaded', () => {
 		console.error('No metrics attributes found in the container.');
 		return;
 	}
-	const { type } = JSON.parse(metricsAttributes);
-	let apiPath = `metrics/${type}`;
-	if ('site' == type) {
-		const siteId = window.wpcloudSite?.id;
-		if (!siteId) {
-			console.error('No site ID found in the window object.');
-			return;
-		}
 
-		apiPath += `/${siteId}`;
+	let apiPath = 'metrics/';
+	const siteId = window.wpcloudSite?.id;
+	if (siteId) {
+		apiPath += 'site/' + siteId;
+	} else {
+		apiPath += 'client'
 	}
 
 	const tree = {

--- a/theme-pico/templates/metrics-wpcloud_site.html
+++ b/theme-pico/templates/metrics-wpcloud_site.html
@@ -15,8 +15,56 @@
 <!-- wp:wpcloud/metrics -->
 <div class="wp-block-wpcloud-metrics" id="metrics"><!-- wp:group {"metadata":{"name":"Graphs"},"className":"wpcloud-metrics","layout":{"type":"grid","columnCount":2,"minimumColumnWidth":null}} -->
 <div class="wp-block-group wpcloud-metrics"><!-- wp:wpcloud/graph {"type":"bar"} -->
-<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;status_codes&quot;,&quot;type&quot;:&quot;bar&quot;,&quot;title&quot;:&quot;Status Codes&quot;,&quot;showLegend&quot;:true}">Graph</div>
-<!-- /wp:wpcloud/graph --></div>
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;http_status&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;1&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Requests by HTTP Response Code&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"response_bytes_persec","dimension":"atomic_site_id","resolution":"60","topX":"1","title":"Bandwidth","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;response_bytes_persec&quot;,&quot;dimension&quot;:&quot;atomic_site_id&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;1&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Bandwidth&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"cgroup_cpu_usage_persec","dimension":"atomic_site_id","resolution":"60","topX":"1","title":"PHP CPU (cores)","showLegend":false,"allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;cgroup_cpu_usage_persec&quot;,&quot;dimension&quot;:&quot;atomic_site_id&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;1&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;PHP CPU (cores)&quot;,&quot;showLegend&quot;:false,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"is_upstream_cached","resolution":"60","title":"HTTP Requests per 1m","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;is_upstream_cached&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;HTTP Requests per 1m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"response_bytes_average","dimension":"is_upstream_cached","resolution":"60","title":"Average HTTP Request Time","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;response_bytes_average&quot;,&quot;dimension&quot;:&quot;is_upstream_cached&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Average HTTP Request Time&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"visitor_is_logged_in","resolution":"60","title":"Requests to wp-admin/admin-ajax.php per 1m","predefinedFilters":[["request_url_no_qs","=","/wp-admin/admin-ajax.php"]],"allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;visitor_is_logged_in&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Requests to wp-admin/admin-ajax.php per 1m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[[&quot;request_url_no_qs&quot;,&quot;=&quot;,&quot;/wp-admin/admin-ajax.php&quot;]],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"admin_ajax_action","resolution":"300","title":"wp-admin/admin-ajax.php actions per 5m","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;admin_ajax_action&quot;,&quot;resolution&quot;:&quot;300&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;wp-admin/admin-ajax.php actions per 5m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"asn","resolution":"300","topX":"10","title":"Top AS Numbers per 5m","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;asn&quot;,&quot;resolution&quot;:&quot;300&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;10&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Top AS Numbers per 5m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"is_crawler","resolution":"120","title":"Bot vs Not-bot per 2m","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;is_crawler&quot;,&quot;resolution&quot;:&quot;120&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Bot vs Not-bot per 2m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"dimension":"proxy_type","resolution":"300","topX":"10","title":"Proxy Type per 5m","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;requests&quot;,&quot;dimension&quot;:&quot;proxy_type&quot;,&quot;resolution&quot;:&quot;300&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;10&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Proxy Type per 5m&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"mysql_cpu_time_persec","dimension":"atomic_site_id","resolution":"60","title":"MySQL CPU (cores)","showLegend":false,"allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;mysql_cpu_time_persec&quot;,&quot;dimension&quot;:&quot;atomic_site_id&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;MySQL CPU (cores)&quot;,&quot;showLegend&quot;:false,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"mysql_rows_inserted_persec","dimension":"atomic_site_id","resolution":"60","title":"Change Rows per 1m (multi-metric)","allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;mysql_rows_inserted_persec&quot;,&quot;dimension&quot;:&quot;atomic_site_id&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Change Rows per 1m (multi-metric)&quot;,&quot;showLegend&quot;:true,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph -->
+
+	<!-- wp:wpcloud/graph {"metric":"mysql_binlog_bytes_written_persec","dimension":"atomic_site_id","resolution":"60","title":"Binary Log Bytes Written per 1m","showLegend":false,"allowFrontendFilters":false} -->
+	<div class="wp-block-wpcloud-graph" data-graph-attributes="{&quot;metric&quot;:&quot;mysql_binlog_bytes_written_persec&quot;,&quot;dimension&quot;:&quot;atomic_site_id&quot;,&quot;resolution&quot;:&quot;60&quot;,&quot;summarize&quot;:false,&quot;topX&quot;:&quot;20&quot;,&quot;type&quot;:&quot;line&quot;,&quot;orientation&quot;:&quot;vertical&quot;,&quot;title&quot;:&quot;Binary Log Bytes Written per 1m&quot;,&quot;showLegend&quot;:false,&quot;minWidth&quot;:&quot;500px&quot;,&quot;predefinedFilters&quot;:[],&quot;allowFrontendFilters&quot;:false}">Graph</div>
+	<!-- /wp:wpcloud/graph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:wpcloud/metrics --></div>
 <!-- /wp:column -->


### PR DESCRIPTION
Currently we are not setting any attributes to define if the Metrics should be pulled for a site or at the client level. As such we need to update the metrics.view.js to remove the type attribute and infer what data to query on based on if there is an atomic_site_id in context.

In addition this PR includes a new export of the metrics-wpcloud_site.html template with first versions of graphs to align with Cirrus