### PR TITLE
Graph Blocks :: Clickthrough for host and atomic_site_id labels

### DIFF
--- a/plugin/blocks/src/components/graph/components/graph.js
+++ b/plugin/blocks/src/components/graph/components/graph.js
@@ -287,6 +287,32 @@ export default function Graph( props ) {
 	const { data: d, ...options } = useGraphOptions({ title, data, series, meta, containerRef, showLegend, type, orientation });
 	const hasData = data.length > 0 && data[0].length > 0;
 
+	// Add u-label event handlers
+	options.hooks = {
+		ready: [
+			(u) => {
+				// Click events for atomic_site_id or http_host labels
+				if( ['atomic_site_id', 'http_host'].includes( dimension ) ) {
+					const labels = u.root.querySelectorAll('.u-label');
+					labels.forEach(label => {
+						label.style.cursor = 'pointer';
+						label.addEventListener('click', (e) => {
+							e.stopPropagation();
+							console.log(`Clicked label: ${label.textContent}`);
+							// sample: sites/spatial-raccoon-jurassic-ninja/metrics/
+							var site_url = label.textContent;
+							if( isNaN( site_url ) ) {
+								site_url = site_url.replace(/\./g, "-");
+							}
+							// Redirect to the single site metrics page.
+							window.location.href = `/sites/${site_url}/metrics/`;
+						});
+					});
+				}
+			},
+		],
+	};
+
 	// Force loading to false after data is loaded
 	useEffect(() => {
 		if (hasData && loading) {

--- a/plugin/includes/class-wpcloud-metrics.php
+++ b/plugin/includes/class-wpcloud-metrics.php
@@ -142,7 +142,7 @@ class WPCloud_Metrics {
 		}
 
 		$result = $wpcloud_client->post( $path, $options );
-		wpcloud_l( 'metrics results', $result->data );
+		//wpcloud_l( 'metrics results', $result->data );
 
 		if ( ! $result->is_ok() ) {
 			$this->result = $result->error;

--- a/plugin/init.php
+++ b/plugin/init.php
@@ -63,6 +63,27 @@ if ( ! is_admin() ) {
 			}
 		}
 	);
+
+}
+
+// Redirect for WPCloud Site ID click-through, should we handle this differently?
+add_filter( 'template_redirect', 'wpcloud_redirect_site_id' );
+function wpcloud_redirect_site_id() {
+	error_log( 'in wpcloud_redirect_site_id' );
+	global $wp_query;
+	if ( isset( $wp_query->query['view'] ) && 'metrics' === $wp_query->query['view'] ) {
+		if ( isset( $wp_query->query['site_name'] ) && is_numeric( $wp_query->query['site_name'] ) ) {
+			$wpcloud_site_id = $wp_query->query['site_name'];
+
+			global $wpdb;
+			$post_name = $wpdb->get_var("SELECT p.post_name FROM $wpdb->posts p JOIN $wpdb->postmeta pm ON p.ID = pm.post_id WHERE meta_key = 'wpcloud_site_id' AND  meta_value = '$wpcloud_site_id' LIMIT 1" );
+			if ( ! is_null( $post_name ) ) {
+				header('Location: /sites/' . $post_name. '/metrics/' );
+				die();
+			}
+
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Enable the ability to click through to site specific metrics from the performance dashboard.

- add setup hook for u-plot so that if the dimension is http_host or atomic_site_id so click performs redirect to sites/Xxx/metrics
- add template_redirect to handle lookup of atomic_site_id and redirect to domain

