### PR TITLE
Metrics: Stacked bar chart legend filtering

### DIFF
--- a/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
+++ b/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
@@ -270,66 +270,7 @@ export function seriesBarsPlugin(opts = {}) {
 			uPlot.assign(opts, {
 				select: {show: false},
 				cursor: {
-					x: false,
-					y: false,
-					dataIdx: (u, seriesIdx) => {
-						if (seriesIdx == 1) {
-							hRect = null;
-
-							let cx = u.cursor.left * pxRatio;
-							let cy = u.cursor.top * pxRatio;
-
-							qt.get(cx, cy, 1, 1, o => {
-								if (pointWithin(cx, cy, o.x, o.y, o.x + o.w, o.y + o.h))
-									hRect = o;
-							});
-						}
-
-						return hRect && seriesIdx == hRect.sidx ? hRect.didx : null;
-					},
-					points: {
-						// Use a lighter fill color for the hover effect
-						fill: "rgba(255,255,255,0.2)",
-						// Ensure no rounding of corners
-						stroke: "transparent",
-						width: 0,
-						// Use a custom shape function to draw a rectangle instead of an oval
-						shape: (u, seriesIdx, dataIdx, cx, cy, radius) => {
-							if (hRect) {
-								const ctx = u.ctx;
-
-								// Get the dimensions of the bar
-								const barX = hRect.x;
-								const barY = hRect.y;
-								const barWidth = hRect.w;
-								const barHeight = hRect.h;
-
-								// Draw a rectangle over the bar
-								ctx.fillRect(barX, barY, barWidth, barHeight);
-							}
-						},
-						// Return the exact dimensions of the bar for the hover effect
-						bbox: (u, seriesIdx) => {
-							let isHovered = hRect && seriesIdx == hRect.sidx;
-
-							if (!isHovered) {
-								return {
-									left: -10,
-									top: -10,
-									width: 0,
-									height: 0,
-								};
-							}
-
-							// Return the exact dimensions of the bar
-							return {
-								left: hRect.x / pxRatio,
-								top: hRect.y / pxRatio,
-								width: hRect.w / pxRatio,
-								height: hRect.h / pxRatio,
-							};
-						}
-					}
+					show: false, // Completely disable the cursor/hover effect
 				},
 				scales: {
 					x: {
@@ -406,8 +347,8 @@ export function seriesBarsPlugin(opts = {}) {
 					uPlot.assign(s, {
 						paths: barsBuilder,
 						points: {
-							// Don't show points (totals) for stacked bar graphs
-							show: (i == opts.series.length-1 && !stacked && drawPoints)
+							// Don't show points (totals) for any bar graphs
+							show: false
 						}
 					});
 				}

--- a/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
+++ b/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
@@ -106,6 +106,30 @@ export function isolateStackedPlugin(originalData) {
 }
 
 /**
+ * Plugin that prevents legend clicks for non-stacked bar charts
+ */
+export function preventLegendClickPlugin() {
+	return {
+		hooks: {
+			ready: (u) => {
+				// Find the legend element
+				const legendEl = u.root.querySelector(".u-legend");
+
+				if (legendEl) {
+					// Add capture phase event listener to intercept clicks before they reach uPlot's handlers
+					legendEl.addEventListener("click", (e) => {
+						// Stop propagation and prevent default to block uPlot's default behavior
+						e.stopPropagation();
+						e.preventDefault();
+						return false;
+					}, true); // true for capture phase
+				}
+			}
+		}
+	};
+}
+
+/**
  * This from https://github.com/leeoniya/uPlot/blob/4315544c319a2c9d561ebd29f54d06a034fb16f6/demos/grouped-bars.js
  */
 export function seriesBarsPlugin(opts = {}) {
@@ -242,6 +266,9 @@ export function seriesBarsPlugin(opts = {}) {
 				u.series.forEach(s => {
 					s._paths = null;
 				});
+
+				// Make the quadtree available to other plugins
+				u.qt = qt;
 
 				barsPctLayout = [null].concat(distrTwo(u.data[0].length, u.series.length - 1 - ignore.length, !stacked, groupWidth));
 

--- a/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
+++ b/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
@@ -378,7 +378,8 @@ export function seriesBarsPlugin(opts = {}) {
 					uPlot.assign(s, {
 						paths: barsBuilder,
 						points: {
-							show:  (i == opts.series.length-1  && drawPoints)
+							// Don't show points (totals) for stacked bar graphs
+							show: (i == opts.series.length-1 && !stacked && drawPoints)
 						}
 					});
 				}

--- a/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
+++ b/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
@@ -114,8 +114,6 @@ export function seriesBarsPlugin(opts = {}) {
 
 	let { ignore = [] } = opts;
 
-	let radius = opts.radius ?? 0;
-
 	function setPxRatio() {
 		pxRatio = devicePixelRatio;
 		font = Math.round(10 * pxRatio) + "px Arial";
@@ -153,7 +151,7 @@ export function seriesBarsPlugin(opts = {}) {
 	let barsColors;
 
 	let barsBuilder = uPlot.paths.bars({
-		radius,
+		radius: 0,
 		disp: {
 			x0: {
 				unit: 2,
@@ -290,15 +288,45 @@ export function seriesBarsPlugin(opts = {}) {
 						return hRect && seriesIdx == hRect.sidx ? hRect.didx : null;
 					},
 					points: {
-						fill: "rgba(255,255,255, 0.3)",
+						// Use a lighter fill color for the hover effect
+						fill: "rgba(255,255,255,0.2)",
+						// Ensure no rounding of corners
+						stroke: "transparent",
+						width: 0,
+						// Use a custom shape function to draw a rectangle instead of an oval
+						shape: (u, seriesIdx, dataIdx, cx, cy, radius) => {
+							if (hRect) {
+								const ctx = u.ctx;
+
+								// Get the dimensions of the bar
+								const barX = hRect.x;
+								const barY = hRect.y;
+								const barWidth = hRect.w;
+								const barHeight = hRect.h;
+
+								// Draw a rectangle over the bar
+								ctx.fillRect(barX, barY, barWidth, barHeight);
+							}
+						},
+						// Return the exact dimensions of the bar for the hover effect
 						bbox: (u, seriesIdx) => {
 							let isHovered = hRect && seriesIdx == hRect.sidx;
 
+							if (!isHovered) {
+								return {
+									left: -10,
+									top: -10,
+									width: 0,
+									height: 0,
+								};
+							}
+
+							// Return the exact dimensions of the bar
 							return {
-								left:   isHovered ? hRect.x / pxRatio : -10,
-								top:    isHovered ? hRect.y / pxRatio : -10,
-								width:  isHovered ? hRect.w / pxRatio : 0,
-								height: isHovered ? hRect.h / pxRatio : 0,
+								left: hRect.x / pxRatio,
+								top: hRect.y / pxRatio,
+								width: hRect.w / pxRatio,
+								height: hRect.h / pxRatio,
 							};
 						}
 					}

--- a/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
+++ b/plugin/blocks/src/components/graph/components/lib/uplot-plugins.js
@@ -7,6 +7,105 @@ import Quadtree, { pointWithin } from './quadtree.js';
 import { distr, SPACE_BETWEEN } from './distr.js';
 
 /**
+ * Plugin that customizes legend clicks
+ * When a legend item is clicked, it shows only that series and hides all others
+ */
+export function isolateStackedPlugin(originalData) {
+	let activeSeriesIdx = null; // Track which series is currently active
+	let stackedData = null; // Store the stacked data
+
+	return {
+		hooks: {
+			ready: (u) => {
+
+				// Store the stacked data that's currently in the chart
+				if (u.data && Array.isArray(u.data) && u.data.length > 0) {
+					stackedData = [...u.data];
+				}
+
+				// Find the legend element
+				const legendEl = u.root.querySelector(".u-legend");
+
+				if (legendEl) {
+					// Add capture phase event listener to intercept clicks before they reach uPlot's handlers
+					legendEl.addEventListener("click", (e) => {
+						// Stop propagation and prevent default to block uPlot's default behavior
+						e.stopPropagation();
+						e.preventDefault();
+
+						// Find the closest legend item (tr element)
+						const target = e.target;
+						const legendItem = target.closest("tr");
+
+						if (!legendItem) {
+							return false;
+						}
+
+						// Find all legend items (tr elements)
+						const legendItems = legendEl.querySelectorAll("tr");
+
+						// Get the index of the clicked legend item
+						let clickedIdx = Array.from(legendItems).indexOf(legendItem);
+
+						// If the same item is clicked again, show all series
+						if (activeSeriesIdx === clickedIdx) {
+							console.log("Showing all series");
+							// Remove u-off class from all legend items
+							legendItems.forEach(item => {
+								item.classList.remove("u-off");
+							});
+							activeSeriesIdx = null;
+
+							// Restore the stacked data
+							if (stackedData) {
+								u.setData(stackedData);
+							}
+						} else {
+							console.log("Showing only series", clickedIdx);
+							// Apply u-off class to all legend items except the clicked one
+							legendItems.forEach((item, idx) => {
+								if (idx !== clickedIdx) {
+									item.classList.add("u-off");
+								} else {
+									item.classList.remove("u-off");
+								}
+							});
+							activeSeriesIdx = clickedIdx;
+
+							// Replace the data with original data for the clicked series
+							if (originalData && Array.isArray(originalData) && originalData.length > clickedIdx) {
+								++clickedIdx; // Adjust for the x-axis series
+
+								// Create a new data array with just the x-axis values and the clicked series
+								const newData = stackedData.map((series, idx) => {
+									if (idx === 0) {
+										// Keep x-axis values
+										return series;
+									} else if (idx === clickedIdx) {
+										// Use the original unstacked data for this series
+										return originalData[idx];
+									} else {
+										// For other series, create an array of the same length as the x-axis but with null values
+										return Array(stackedData[0].length).fill(null);
+									}
+								});
+
+								// Update the graph with the new data
+								u.setData(newData);
+							}
+						}
+
+						return false;
+					}, true); // true for capture phase
+				} else {
+					console.warn("Legend element not found");
+				}
+			}
+		}
+	};
+}
+
+/**
  * This from https://github.com/leeoniya/uPlot/blob/4315544c319a2c9d561ebd29f54d06a034fb16f6/demos/grouped-bars.js
  */
 export function seriesBarsPlugin(opts = {}) {

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -4,7 +4,7 @@ import chroma from 'chroma-js';
 
 import { useMetricsOptionsContext } from '@wpcloud/metrics/components/contexts';
 
-import { seriesBarsPlugin } from './uplot-plugins';
+import { seriesBarsPlugin, isolateStackedPlugin } from './uplot-plugins';
 import { stack } from './utils';
 
 const statusScale = () => ( series, _, opacity ) => {
@@ -191,7 +191,8 @@ export default ({ containerRef, ...options } ) => {
 		const pluginOptions = { dir, ori };
 		if ( 'stacked-bar' === type ) {
 			pluginOptions.stacked = true;
-			graphOptions = {...graphOptions, ...stack(data)};
+			graphOptions = { ...graphOptions, ...stack(data) };
+			graphOptions.plugins.push(isolateStackedPlugin(data));
 		}
 		graphOptions.plugins.push(seriesBarsPlugin(pluginOptions));
 	}

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -170,7 +170,7 @@ export default ({ containerRef, ...options } ) => {
 		ori:
 		dir,
 		padding,
-		plugins: [],
+		plugins: [], // The hover effect is now integrated into seriesBarsPlugin
 		scales,
 		legend
 	};

--- a/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
+++ b/plugin/blocks/src/components/graph/components/lib/useGraphOptions.js
@@ -4,7 +4,7 @@ import chroma from 'chroma-js';
 
 import { useMetricsOptionsContext } from '@wpcloud/metrics/components/contexts';
 
-import { seriesBarsPlugin, isolateStackedPlugin } from './uplot-plugins';
+import { seriesBarsPlugin, isolateStackedPlugin, preventLegendClickPlugin, tooltipPlugin } from './uplot-plugins';
 import { stack } from './utils';
 
 const statusScale = () => ( series, _, opacity ) => {
@@ -193,7 +193,11 @@ export default ({ containerRef, ...options } ) => {
 			pluginOptions.stacked = true;
 			graphOptions = { ...graphOptions, ...stack(data) };
 			graphOptions.plugins.push(isolateStackedPlugin(data));
+		} else {
+			// For non-stacked bar charts, prevent legend clicks
+			graphOptions.plugins.push(preventLegendClickPlugin());
 		}
+
 		graphOptions.plugins.push(seriesBarsPlugin(pluginOptions));
 	}
 

--- a/theme-pico/assets/blocks/src/wpcloud-graph.css
+++ b/theme-pico/assets/blocks/src/wpcloud-graph.css
@@ -1,30 +1,29 @@
 
+.u-cursor-pt {
+	border-radius: 0;
+}
+
+.u-legend {
+	.u-marker {
+		height: .25em;
+		border-radius: 0.125em;
+	}
+}
+
+.u-title {
+	padding: 10px 0;
+	margin: 0;
+}
+
+.u-series {
+	th, td {
+		background: none;
+	}
+}
+
 & {
-	.u-title {
-		padding: 10px 0;
-		margin: 0;
-	}
-
-	.u-legend {
-		.u-marker {
-			height: .25em !important;
-			border-radius: 0.125em;
-		}
-	}
-
-	.u-series {
-		th, td {
-			background: none;
-		}
-
-	}
-
-	@media (prefers-color-scheme: dark) {
-		& {
-			border-radius: var(--pico-border-radius);
-			border: var(--pico-border-width) solid var(--pico-form-element-border-color);
-			background-color: var(--pico-form-element-background-color);
-			color: var(--pico-form-element-placeholder-color);
-		}
-	}
+	border-radius: var(--pico-border-radius);
+	border: var(--pico-border-width) solid var(--pico-form-element-border-color);
+	background-color: var(--pico-form-element-background-color);
+	color: var(--pico-form-element-placeholder-color);
 }

--- a/theme-pico/assets/blocks/src/wpcloud-graph.css
+++ b/theme-pico/assets/blocks/src/wpcloud-graph.css
@@ -1,7 +1,6 @@
-
-.u-cursor-pt {
+ .u-cursor-pt {
 	border-radius: 0;
-}
+ }
 
 .u-legend {
 	.u-marker {

--- a/theme-pico/assets/blocks/src/wpcloud-graph.css
+++ b/theme-pico/assets/blocks/src/wpcloud-graph.css
@@ -1,28 +1,29 @@
- .u-cursor-pt {
-	border-radius: 0;
- }
-
-.u-legend {
-	.u-marker {
-		height: .25em;
-		border-radius: 0.125em;
-	}
-}
-
-.u-title {
-	padding: 10px 0;
-	margin: 0;
-}
-
-.u-series {
-	th, td {
-		background: none;
-	}
-}
 
 & {
-	border-radius: var(--pico-border-radius);
-	border: var(--pico-border-width) solid var(--pico-form-element-border-color);
-	background-color: var(--pico-form-element-background-color);
-	color: var(--pico-form-element-placeholder-color);
+	.u-title {
+		padding: 10px 0;
+		margin: 0;
+	}
+
+	.u-legend {
+		.u-marker {
+			height: .25em !important;
+			border-radius: 0.125em;
+		}
+	}
+
+	.u-series {
+		th, td {
+			background: none;
+		}
+	}
+
+	@media (prefers-color-scheme: dark) {
+		& {
+			border-radius: var(--pico-border-radius);
+			border: var(--pico-border-width) solid var(--pico-form-element-border-color);
+			background-color: var(--pico-form-element-background-color);
+			color: var(--pico-form-element-placeholder-color);
+		}
+	}
 }

--- a/theme-pico/theme.json
+++ b/theme-pico/theme.json
@@ -7,7 +7,11 @@
   "styles": {
     "blocks": {
       "wpcloud/graph": {
+<<<<<<< Updated upstream
         "css": "\n.u-cursor-pt {\n\tborder-radius: 0;\n}\n\n.u-legend .u-marker {\n\theight: .25em;\n\tborder-radius: 0.125em;\n}\n\n.u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n.u-series th {\n\tbackground: none;\n}\n\n.u-series td {\n\tbackground: none;\n}\n\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n"
+=======
+        "css": " .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n& .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n\n& .u-series th {\n\tbackground: none;\n}\n\n& .u-series td {\n\tbackground: none;\n}\n\n@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
+>>>>>>> Stashed changes
       }
     }
   }

--- a/theme-pico/theme.json
+++ b/theme-pico/theme.json
@@ -7,15 +7,7 @@
   "styles": {
     "blocks": {
       "wpcloud/graph": {
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-        "css": "\n.u-cursor-pt {\n\tborder-radius: 0;\n}\n\n.u-legend .u-marker {\n\theight: .25em;\n\tborder-radius: 0.125em;\n}\n\n.u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n.u-series th {\n\tbackground: none;\n}\n\n.u-series td {\n\tbackground: none;\n}\n\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n"
-=======
-        "css": " .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n& .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n\n& .u-series th {\n\tbackground: none;\n}\n\n& .u-series td {\n\tbackground: none;\n}\n\n@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
->>>>>>> Stashed changes
-=======
-        "css": " .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n& .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n\n& .u-series th {\n\tbackground: none;\n}\n\n& .u-series td {\n\tbackground: none;\n}\n\n@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
->>>>>>> Stashed changes
+        "css": "\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n& .u-series th {\n\tbackground: none;\n}\n& .u-series td {\n\tbackground: none;\n}\n\t@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
       }
     }
   }

--- a/theme-pico/theme.json
+++ b/theme-pico/theme.json
@@ -8,7 +8,11 @@
     "blocks": {
       "wpcloud/graph": {
 <<<<<<< Updated upstream
+<<<<<<< Updated upstream
         "css": "\n.u-cursor-pt {\n\tborder-radius: 0;\n}\n\n.u-legend .u-marker {\n\theight: .25em;\n\tborder-radius: 0.125em;\n}\n\n.u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n.u-series th {\n\tbackground: none;\n}\n\n.u-series td {\n\tbackground: none;\n}\n\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n"
+=======
+        "css": " .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n& .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n\n& .u-series th {\n\tbackground: none;\n}\n\n& .u-series td {\n\tbackground: none;\n}\n\n@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
+>>>>>>> Stashed changes
 =======
         "css": " .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n& .u-cursor-pt {\n\tborder-radius: 0;\n }\n\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n\n& .u-series th {\n\tbackground: none;\n}\n\n& .u-series td {\n\tbackground: none;\n}\n\n@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
 >>>>>>> Stashed changes

--- a/theme-pico/theme.json
+++ b/theme-pico/theme.json
@@ -7,7 +7,7 @@
   "styles": {
     "blocks": {
       "wpcloud/graph": {
-        "css": "\n& .u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n& .u-legend .u-marker {\n\theight: .25em !important;\n\tborder-radius: 0.125em;\n}\n& .u-series th {\n\tbackground: none;\n}\n& .u-series td {\n\tbackground: none;\n}\n\t@media (prefers-color-scheme: dark) {\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n}\n"
+        "css": "\n.u-cursor-pt {\n\tborder-radius: 0;\n}\n\n.u-legend .u-marker {\n\theight: .25em;\n\tborder-radius: 0.125em;\n}\n\n.u-title {\n\tpadding: 10px 0;\n\tmargin: 0;\n}\n\n.u-series th {\n\tbackground: none;\n}\n\n.u-series td {\n\tbackground: none;\n}\n\n& {\n\tborder-radius: var(--pico-border-radius);\n\tborder: var(--pico-border-width) solid var(--pico-form-element-border-color);\n\tbackground-color: var(--pico-form-element-background-color);\n\tcolor: var(--pico-form-element-placeholder-color);\n}\n"
       }
     }
   }


### PR DESCRIPTION
The stacked bar chart had an issue where clicking the series in the legend would hide the series but would not recalculate the stacked data. This seems to be a root issue with the recommended plugin for stacking bar data.

I noticed that in grafana the stacked data series will highlight the clicked series rather than hide it.

This PR does exactly that.
Clicking on a series in a stacked bar chart will hide all the other series. Clicking on a highlighted series will reset the graph 

![Screen Recording 2025-04-30 at 10 58 19 PM](https://github.com/user-attachments/assets/4d5e6554-bd0d-4577-9998-117391549fb8)
