### PR TITLE
Pico Theme : Update default width to 1200px

### DIFF
--- a/theme-pico/templates/page.html
+++ b/theme-pico/templates/page.html
@@ -9,8 +9,8 @@
 <div class="wp-block-column"></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"600px"} -->
-<div class="wp-block-column" style="flex-basis:600px"><!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} /--></div>
+<!-- wp:column {"width":"1200px"} -->
+<div class="wp-block-column" style="flex-basis:1200px"><!-- wp:post-content {"lock":{"move":false,"remove":false},"layout":{"type":"constrained"}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":""} -->


### PR DESCRIPTION
600px is not functional for Metrics or table views/ menus. 

Increasing to 1200px as we have content and lets show it.