### PR TITLE
Metrics : top_x User param equates to max_bucket_size in the Atomic.API

### DIFF
--- a/plugin/controllers/class-wpcloud-metrics-controller.php
+++ b/plugin/controllers/class-wpcloud-metrics-controller.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WPCLOUD_Metrics_Controller' ) ) {
 				$summarize = $params['summarize'] ?? false;
 
 				$options = array(
-					'top_x'      => $params['top_x'] ?? 20,
+					'max_bucket_size'      => $params['top_x'] ?? 20, //top_x is max_bucket_size in Metrics API.
 					'resolution' => $params['resolution'] ?? 10,
 				);
 


### PR DESCRIPTION
We've settled on TOP X for the user nomenclature, however the Atomic.API has it as max_bucket_size. This ensures we are passing the user selected param to the API so we limit the data accordingly.