### PR TITLE
Build: Update release cut scripts

### DIFF
--- a/bin/cut.js
+++ b/bin/cut.js
@@ -5,41 +5,70 @@ const createRelease = require('./tools/release.js');
 // Configuration
 const POLL_INTERVAL = 10000; // Check every 10 seconds
 
-// Function to check PR mergeability
-async function isMergeable(prNumber) {
+// Function to check PR mergeability and test status
+async function isPRReadyToMerge(prNumber) {
 	try {
-		// Execute the `gh` command to get PR details
-		const output = execSync(`gh pr view ${prNumber} --json mergeable`, { encoding: 'utf8' })
+		// Execute the `gh` command to get PR details including mergeable status and status checks
+		const output = execSync(`gh pr view ${prNumber} --json mergeable,statusCheckRollup`, { encoding: 'utf8' })
 
 		// Parse the JSON output
 		const prData = JSON.parse(output);
 
-		// Return the mergeable status
-		return prData.mergeable === 'MERGEABLE';
+		// Check if PR is mergeable
+		const isMergeable = prData.mergeable === 'MERGEABLE';
+
+		// Check if all required status checks have passed
+		let allTestsPassed = true;
+		if (prData.statusCheckRollup && prData.statusCheckRollup.length > 0) {
+			for (const check of prData.statusCheckRollup) {
+				// Consider only required checks or all checks if none are explicitly required
+				if (check.state !== 'SUCCESS') {
+					allTestsPassed = false;
+					console.log(`Status check "${check.name}" is in state "${check.state}"`);
+					break;
+				}
+			}
+		} else {
+			console.log('No status checks found for this PR');
+		}
+
+		return {
+			mergeable: isMergeable,
+			testsPassed: allTestsPassed,
+			readyToMerge: isMergeable && allTestsPassed
+		};
 	} catch (error) {
 		console.error(`Error fetching PR details: ${error.message}`);
-		return null;
+		return {
+			mergeable: null,
+			testsPassed: null,
+			readyToMerge: false
+		};
 	}
 }
 
-// Function to wait for PR to be mergeable
-async function waitForMergeable(prNumber) {
-	console.log(`Waiting for PR #${prNumber} to become mergeable...`);
+// Function to wait for PR to be mergeable and tests to pass
+async function waitForPRReadyToMerge(prNumber) {
+	console.log(`Waiting for PR #${prNumber} to become mergeable and tests to pass...`);
 
 	while (true) {
 		try {
-			const mergeable = await isMergeable(prNumber);
+			const status = await isPRReadyToMerge(prNumber);
 
-			if (mergeable === true) {
-				console.log(`PR #${prNumber} is mergeable!`);
+			if (status.readyToMerge) {
+				console.log(`PR #${prNumber} is mergeable and all tests have passed!`);
 				break;
-			} else if (mergeable === false) {
-				console.log(`PR #${prNumber} is not mergeable. Retrying...`);
 			} else {
-				console.log(`Mergeable status is unknown. Retrying...`);
+				if (!status.mergeable) {
+					console.log(`PR #${prNumber} is not mergeable. Retrying...`);
+				} else if (!status.testsPassed) {
+					console.log(`PR #${prNumber} is mergeable but tests have not passed. Retrying...`);
+				} else {
+					console.log(`PR #${prNumber} status is unknown. Retrying...`);
+				}
 			}
 		} catch (error) {
-			console.error(`Error checking mergeability: ${error.message}`);
+			console.error(`Error checking PR status: ${error.message}`);
 		}
 
 		// Wait before retrying
@@ -63,7 +92,7 @@ async function main() {
 	}
 
 	// Start the script
-	await waitForMergeable(prNum);
+	await waitForPRReadyToMerge(prNum);
 
 	execSync(`gh pr merge ${prNum} --admin --squash`);
 	createRelease();

--- a/bin/tools/release.js
+++ b/bin/tools/release.js
@@ -38,7 +38,6 @@ function releaseExists(tag) {
 }
 
 // Function to get PRs between two tags
-// @TODO: fix this
 function getPRsBetweenTags(previousTag, currentTag) {
 	if (!previousTag) {
 			console.log('No previous tag found. Cannot list PRs.');
@@ -46,12 +45,57 @@ function getPRsBetweenTags(previousTag, currentTag) {
 	}
 
 	console.log(`Fetching PRs between ${previousTag} and ${currentTag}...`);
-	const previousTagDate = execSync( `git log -1 --format=%ci ${previousTag}`, { encoding: 'utf8' }).split(' ')[0];
-	const currentTagDate = execSync( `git log -1 --format=%ci ${currentTag}`, { encoding: 'utf8' }).split(' ')[0];
-	const prs = execSync(
-			`gh pr list --search "merged:${previousTagDate}..${currentTagDate}" --json title,number --jq ".[] | \\\"#\\(.number) \\(.title)\\\""`, {encoding: 'utf8'}
-	);
-	return prs ? prs.split('\n') : [];
+
+	// Get the commit range between the two tags
+	const commitRange = `${previousTag}..${currentTag}`;
+
+	// Get the list of commit SHAs in the range
+	const commits = execSync(`git log --pretty=format:"%H" ${commitRange}`, { encoding: 'utf8' })
+		.trim()
+		.split('\n');
+
+	if (!commits || commits.length === 0) {
+		console.log('No commits found between tags.');
+		return [];
+	}
+
+	// Create a query to find PRs that include these commits
+	// We'll use the GitHub search syntax to find PRs that include any of these commits
+	const prNumbers = new Set();
+	const prDetails = [];
+
+	// Process commits in batches to avoid command line length limits
+	const batchSize = 10;
+	for (let i = 0; i < commits.length; i += batchSize) {
+		const batchCommits = commits.slice(i, i + batchSize);
+
+		// For each commit, try to find the associated PR
+		for (const commit of batchCommits) {
+			try {
+				// Use GitHub CLI to get the PR number for this commit
+				const prInfo = execSync(`gh pr list --search "hash:${commit}" --json number,title --limit 1`,
+					{ encoding: 'utf8' });
+
+				if (prInfo && prInfo.trim()) {
+					const prData = JSON.parse(prInfo);
+					if (prData && prData.length > 0) {
+						const { number, title } = prData[0];
+
+						// Only add if we haven't seen this PR number before
+						if (!prNumbers.has(number)) {
+							prNumbers.add(number);
+							prDetails.push(`#${number} ${title}`);
+						}
+					}
+				}
+			} catch (error) {
+				console.log(`Could not find PR for commit ${commit.substring(0, 8)}`);
+			}
+		}
+	}
+
+	console.log(`Found ${prDetails.length} PRs between ${previousTag} and ${currentTag}`);
+	return prDetails;
 }
 
 // Function to get the previous tag


### PR DESCRIPTION
This updates the `npm run cut` command to:
1. Wait till the tests pass before merging the release PR
2. Fixes how many PRs it grabs for the release notes.