### PR TITLE
Fix critical npm alerts

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -7318,9 +7318,9 @@
 			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-			"integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
+			"integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11374,13 +11374,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -43,5 +43,9 @@
 		"remove-accents": "~0.5.0",
 		"uplot": "~1.6.31",
 		"uplot-react": "~1.2.2"
+	},
+	"overrides": {
+		"basic-ftp": "5.2.1",
+		"form-data": "4.0.4"
 	}
 }


### PR DESCRIPTION
## Summary
- Override vulnerable transitive dev dependencies in the plugin package: `basic-ftp@5.2.1` and `form-data@4.0.4`.
- Refresh `plugin/package-lock.json` so the critical Dependabot alerts resolve.
- Dependabot security updates are enabled for this repo.

## Validation
- `npm ci --ignore-scripts`
- `npm audit --audit-level=critical --json` reported 0 critical findings
- `npm ls basic-ftp form-data --all`
- `npm run build`
- `npm test`
- `composer validate --no-check-publish`
- `git diff --check`

Known existing gaps:
- `npm run lint:js` fails on existing JS/prettier issues in untouched files.
- `npm run lint:css` fails because the configured CSS glob matches no files.
- `composer validate --strict` reports the existing missing-license warning.