### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.3.2
+        uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f # v1.3.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           tools: composer:v2
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           extensions: mbstring, intl, mysqli, zip
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: '8.1'
           extensions: mbstring, intl, mysqli, zip
@@ -298,7 +298,7 @@ jobs:
         run: echo "No composer.json found in plugin directory, skipping dependency installation"
 
       - name: Set up MySQL
-        uses: mirromutth/mysql-action@v1.1
+        uses: mirromutth/mysql-action@de1fba8b3f90ce8db80f663a7043be3cf3231248 # v1.1
         with:
           mysql version: '5.7'
           mysql database: 'wordpress_test'


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 5
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# bruceadams/get-release # v1.3.2 -> 74c3d60f5a28f358ccf241a00c9021ea16f0569f
gh api repos/bruceadams/get-release/commits/v1.3.2 --jq '.sha'
# expected: 74c3d60f5a28f358ccf241a00c9021ea16f0569f

# mirromutth/mysql-action # v1.1 -> de1fba8b3f90ce8db80f663a7043be3cf3231248
gh api repos/mirromutth/mysql-action/commits/v1.1 --jq '.sha'
# expected: de1fba8b3f90ce8db80f663a7043be3cf3231248

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
```
